### PR TITLE
Database and core proc

### DIFF
--- a/core/src/main/java/uk/ac/ucl/rits/inform/datasinks/emapstar/controllers/VisitObservationController.java
+++ b/core/src/main/java/uk/ac/ucl/rits/inform/datasinks/emapstar/controllers/VisitObservationController.java
@@ -19,6 +19,7 @@ import uk.ac.ucl.rits.inform.informdb.visit_recordings.VisitObservationType;
 import uk.ac.ucl.rits.inform.informdb.visit_recordings.VisitObservationTypeAudit;
 import uk.ac.ucl.rits.inform.interchange.visit_observations.Flowsheet;
 import uk.ac.ucl.rits.inform.interchange.visit_observations.FlowsheetMetadata;
+import uk.ac.ucl.rits.inform.interchange.visit_observations.WaveformMessage;
 
 import javax.annotation.Resource;
 import java.time.Instant;
@@ -120,6 +121,22 @@ public class VisitObservationController {
             flowsheetState.saveEntityOrAuditLogIfRequired(visitObservationRepo, visitObservationAuditRepo);
             updateDataFlagsAndSaveObservationType(msg, observationType, validFrom, storedFrom);
         }
+    }
+
+    /**
+     * Process the parts of a waveform message that relate to its visit observation type.
+     * @param msg waveform msg from which to extract VisitObservationType data
+     * @param storedFrom stored from
+     * @return new or existing VisitObservationType
+     */
+    public VisitObservationType getOrCreateFromWaveform(WaveformMessage msg, Instant storedFrom) {
+//        RowState<VisitObservationType, VisitObservationTypeAudit> observationType = getOrCreateObservationTypeState(
+        VisitObservationType observationType = cache.getOrCreatePersistedObservationType(
+                msg.getSourceStreamId(), msg.getSourceStreamId(), "waveform", msg.getObservationTime(), storedFrom);
+        observationType.setName(msg.getMappedStreamDescription());
+        observationType.setIsRealTime(true);
+        // XXX: what about updates if the description changes over time?
+        return observationType;
     }
 
     /**

--- a/core/src/main/java/uk/ac/ucl/rits/inform/datasinks/emapstar/controllers/WaveformController.java
+++ b/core/src/main/java/uk/ac/ucl/rits/inform/datasinks/emapstar/controllers/WaveformController.java
@@ -5,13 +5,16 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 import uk.ac.ucl.rits.inform.datasinks.emapstar.exceptions.MessageIgnoredException;
+import uk.ac.ucl.rits.inform.datasinks.emapstar.repos.LocationVisitRepository;
 import uk.ac.ucl.rits.inform.datasinks.emapstar.repos.visit_observations.WaveformRepository;
+import uk.ac.ucl.rits.inform.informdb.movement.LocationVisit;
 import uk.ac.ucl.rits.inform.informdb.visit_recordings.Waveform;
 import uk.ac.ucl.rits.inform.interchange.InterchangeValue;
 import uk.ac.ucl.rits.inform.interchange.visit_observations.WaveformMessage;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * Controller for Waveform specific information.
@@ -22,11 +25,14 @@ public class WaveformController {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 
     private final WaveformRepository waveformRepository;
+    private final LocationVisitRepository locationVisitRepository;
 
     WaveformController(
-            WaveformRepository waveformRepository
+            WaveformRepository waveformRepository,
+            LocationVisitRepository locationVisitRepository
     ) {
         this.waveformRepository = waveformRepository;
+        this.locationVisitRepository = locationVisitRepository;
     }
 
     /**
@@ -42,16 +48,23 @@ public class WaveformController {
             throw new MessageIgnoredException("Updating/deleting waveform data is not supported");
         }
         // All given values are put into one new row. It's the responsibility of whoever is
-        // generating the message to chose an appropriate size of array.
+        // generating the message to choose an appropriate size of array.
         List<Double> numericValues = interchangeValue.get();
         Instant observationTime = msg.getObservationTime();
+        // Try to find the visit. We don't have enough information to create the visit if it doesn't already exist.
+        Optional<LocationVisit> inferredLocationVisit =
+                locationVisitRepository.findLocationVisitByLocationAndTime(observationTime, msg.getLocationString());
+        // XXX: will have to do some sanity checks here to be sure that the HL7 feed hasn't gone down.
+        // See issue #36, and here for discussion:
+        // https://github.com/UCLH-DHCT/emap/blob/jeremy/hf-data/docs/dev/features/waveform_hf_data.md#core-processor-logic-orphan-data-problem
         Waveform dataPoint = new Waveform(
                 observationTime,
                 observationTime,
                 storedFrom);
+        inferredLocationVisit.ifPresent(dataPoint::setLocationVisitId);
         Double[] valuesAsArray = numericValues.toArray(new Double[0]);
         dataPoint.setSamplingRate(msg.getSamplingRate());
-        dataPoint.setLocation(msg.getLocationString());
+        dataPoint.setSourceLocation(msg.getLocationString());
         dataPoint.setValuesArray(valuesAsArray);
         waveformRepository.save(dataPoint);
     }

--- a/core/src/main/java/uk/ac/ucl/rits/inform/datasinks/emapstar/dataprocessors/WaveformProcessor.java
+++ b/core/src/main/java/uk/ac/ucl/rits/inform/datasinks/emapstar/dataprocessors/WaveformProcessor.java
@@ -6,10 +6,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
-import uk.ac.ucl.rits.inform.datasinks.emapstar.controllers.PersonController;
-import uk.ac.ucl.rits.inform.datasinks.emapstar.controllers.VisitController;
 import uk.ac.ucl.rits.inform.datasinks.emapstar.controllers.VisitObservationController;
 import uk.ac.ucl.rits.inform.datasinks.emapstar.controllers.WaveformController;
+import uk.ac.ucl.rits.inform.informdb.visit_recordings.VisitObservationType;
 import uk.ac.ucl.rits.inform.interchange.EmapOperationMessageProcessingException;
 import uk.ac.ucl.rits.inform.interchange.visit_observations.WaveformMessage;
 
@@ -23,8 +22,6 @@ import java.time.temporal.ChronoUnit;
 @Component
 public class WaveformProcessor {
     private final Logger logger = LoggerFactory.getLogger(getClass());
-    private final PersonController personController;
-    private final VisitController visitController;
     private final VisitObservationController visitObservationController;
     private final WaveformController waveformController;
 
@@ -34,16 +31,12 @@ public class WaveformProcessor {
     private boolean isSyntheticData;
 
     /**
-     * @param personController           person controller.
-     * @param visitController            visit controller
      * @param visitObservationController visit observation controller
      * @param waveformController         waveform controller
      */
     public WaveformProcessor(
-            PersonController personController, VisitController visitController, VisitObservationController visitObservationController,
+            VisitObservationController visitObservationController,
             WaveformController waveformController) {
-        this.personController = personController;
-        this.visitController = visitController;
         this.visitObservationController = visitObservationController;
         this.waveformController = waveformController;
     }
@@ -56,7 +49,8 @@ public class WaveformProcessor {
      */
     @Transactional
     public void processMessage(final WaveformMessage msg, final Instant storedFrom) throws EmapOperationMessageProcessingException {
-        waveformController.processWaveform(msg, storedFrom);
+        VisitObservationType visitObservationType = visitObservationController.getOrCreateFromWaveform(msg, storedFrom);
+        waveformController.processWaveform(msg, visitObservationType, storedFrom);
     }
 
 

--- a/core/src/main/java/uk/ac/ucl/rits/inform/datasinks/emapstar/repos/LocationVisitRepository.java
+++ b/core/src/main/java/uk/ac/ucl/rits/inform/datasinks/emapstar/repos/LocationVisitRepository.java
@@ -1,5 +1,6 @@
 package uk.ac.ucl.rits.inform.datasinks.emapstar.repos;
 
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import uk.ac.ucl.rits.inform.informdb.identity.HospitalVisit;
 import uk.ac.ucl.rits.inform.informdb.movement.Location;
@@ -69,6 +70,22 @@ public interface LocationVisitRepository extends CrudRepository<LocationVisit, L
     Optional<LocationVisit> findByHospitalVisitIdAndLocationIdAndDischargeDatetime(HospitalVisit visit,
                                                                                    Location locationId,
                                                                                    Instant dischargeDatetime);
+
+    /**
+     * Find a current or closed location visit by any time during that visit and its location.
+     * Intended for when the visit can't be found by its ID, and we have to infer it by time and place.
+     * @param observationDatetime any time when the patient was at that location
+     * @param locationString location string
+     * @return the location visit, if it exists
+     */
+    @Query("from LocationVisit lv "
+            + "inner join lv.locationId as loc "
+            + "where loc.locationString = :locationString "
+            + "and :observationDatetime >= lv.admissionDatetime "
+            + "and (lv.dischargeDatetime is null "
+            + "  or :observationDatetime <= lv.dischargeDatetime) "
+    )
+    Optional<LocationVisit> findLocationVisitByLocationAndTime(Instant observationDatetime, String locationString);
 
     /**
      * For testing: find by location string.

--- a/core/src/main/java/uk/ac/ucl/rits/inform/datasinks/emapstar/repos/visit_observations/VisitObservationTypeRepository.java
+++ b/core/src/main/java/uk/ac/ucl/rits/inform/datasinks/emapstar/repos/visit_observations/VisitObservationTypeRepository.java
@@ -3,6 +3,7 @@ package uk.ac.ucl.rits.inform.datasinks.emapstar.repos.visit_observations;
 import org.springframework.data.repository.CrudRepository;
 import uk.ac.ucl.rits.inform.informdb.visit_recordings.VisitObservationType;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -51,4 +52,11 @@ public interface VisitObservationTypeRepository extends CrudRepository<VisitObse
      * @return Visit Observation Type with interfaceId and idInApplication as specified, if exists.
      */
     Optional<VisitObservationType> findByInterfaceIdAndIdInApplication(String interfaceId, String idInApplication);
+
+    /**
+     * For testing.
+     * @param sourceObservationType source observation type (eg. "waveform")
+     * @return all rows matching
+     */
+    List<VisitObservationType> findAllBySourceObservationType(String sourceObservationType);
 }

--- a/core/src/main/java/uk/ac/ucl/rits/inform/datasinks/emapstar/repos/visit_observations/WaveformRepository.java
+++ b/core/src/main/java/uk/ac/ucl/rits/inform/datasinks/emapstar/repos/visit_observations/WaveformRepository.java
@@ -14,7 +14,25 @@ import java.time.Instant;
  */
 
 public interface WaveformRepository extends CrudRepository<Waveform, Long> {
+    /**
+     * Find waveform entries that have a known association with a location visit (ie. non-orphaned).
+     * @param location location string of the location visit
+     * @return all waveform entries at that location
+     */
+    @Query("select w from Waveform w "
+            + "inner join w.locationVisitId lv "
+            + "inner join lv.locationId as loc "
+            + "where :location = loc.locationString "
+            + "order by w.observationDatetime "
+    )
     Iterable<Waveform> findAllByLocationOrderByObservationDatetime(String location);
+
+    /**
+     * Find waveform entries according to their source location, whether orphaned or not.
+     * @param sourceLocation location according to the source system
+     * @return all entries at that location
+     */
+    Iterable<Waveform> findAllBySourceLocationOrderByObservationDatetime(String sourceLocation);
 
     // the default delete queries are very inefficient so specify manually
     @Modifying

--- a/core/src/test/java/uk/ac/ucl/rits/inform/datasinks/emapstar/waveform/TestWaveformProcessing.java
+++ b/core/src/test/java/uk/ac/ucl/rits/inform/datasinks/emapstar/waveform/TestWaveformProcessing.java
@@ -4,6 +4,7 @@ import lombok.AllArgsConstructor;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.jdbc.Sql;
 import uk.ac.ucl.rits.inform.datasinks.emapstar.MessageProcessingBase;
 import uk.ac.ucl.rits.inform.datasinks.emapstar.repos.HospitalVisitRepository;
 import uk.ac.ucl.rits.inform.datasinks.emapstar.repos.visit_observations.VisitObservationAuditRepository;
@@ -23,8 +24,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -47,26 +51,38 @@ class TestWaveformProcessing extends MessageProcessingBase {
     @AllArgsConstructor
     class TestData {
         int numSamples;
-        int samplingRate;
+        long samplingRate;
         int maxSamplesPerMessage;
         String location;
+        Instant obsDatetime;
+        public Instant getEndObsTime() {
+            return obsDatetime.plus(numSamples * 1000_000L / samplingRate, ChronoUnit.MICROS);
+        }
+        Long expectedLocationVisitId;
     }
 
     @Test
+    @Sql("/populate_db.sql")
     void testAddWaveform() throws EmapOperationMessageProcessingException {
         var allTests = new TestData[]{
                 // Intended to be two patients each connected to two machines, but the nature of the
                 // bed/machine IDs may not quite be like this.
-                new TestData(20_000, 300, 900, "Location1MachineA"),
-                new TestData(25_000, 50, 500, "Location1MachineB"),
-                new TestData(15_000, 300, 900, "Location2MachineC"),
-                new TestData(17_000, 50, 500, "Location2MachineD"),
+                new TestData(20_000, 300, 900,
+                        "T11E^T11E BY02^BY02-25", Instant.parse("2010-09-10T12:00:00Z"), 106001L),
+                new TestData(25_000, 50, 500,
+                        "T42E^T42E BY03^BY03-17", Instant.parse("2010-09-14T15:27:00Z"), 106002L),
+                new TestData(15_000, 300, 900,
+                        // matches location but not time
+                        "T11E^T11E BY02^BY02-25", Instant.parse("2010-09-14T16:00:00Z"), null),
+                new TestData(17_000, 50, 500,
+                        // matches time but not location
+                        "T42E^T42E BY03^BY03-17", Instant.parse("2010-09-10T12:00:00Z"), null)
         };
         List<WaveformMessage> allMessages = new ArrayList<>();
         for (var test: allTests) {
             allMessages.addAll(
                     messageFactory.getWaveformMsgs(
-                            test.samplingRate, test.numSamples, test.maxSamplesPerMessage, test.location));
+                            test.samplingRate, test.numSamples, test.maxSamplesPerMessage, test.location, test.obsDatetime));
         }
 
         // must cope with messages in any order! Fixed seed to aid in debugging.
@@ -76,15 +92,43 @@ class TestWaveformProcessing extends MessageProcessingBase {
             processSingleMessage(msg);
         }
 
+        int totalObservedNumSamples = 0;
         for (var test: allTests) {
-            List<Waveform> actualWaveformsAtLocation = new ArrayList<>();
-            waveformRepository.findAllByLocationOrderByObservationDatetime(test.location).forEach(actualWaveformsAtLocation::add);
-            // make sure we're testing the difficult case of multiple messages that need to be stitched together
-            assertTrue(actualWaveformsAtLocation.size() > 1);
-            Optional<Integer> observedNumSamples = actualWaveformsAtLocation.stream().map(w -> w.getValuesArray().length).reduce(Integer::sum);
+            List<Waveform> waveformRows = filterByDatetimeInterval(
+                    waveformRepository.findAllBySourceLocationOrderByObservationDatetime(test.location),
+                    test.obsDatetime,
+                    test.getEndObsTime());
+
+            assertFalse(waveformRows.isEmpty());
+            // make sure we're testing the difficult case of multiple waveform rows that need to be stitched together
+            assertTrue(waveformRows.size() > 1);
+            Optional<Integer> observedNumSamples = waveformRows.stream().map(w -> w.getValuesArray().length).reduce(Integer::sum);
             assertEquals(test.numSamples, observedNumSamples.orElseThrow());
+            totalObservedNumSamples += observedNumSamples.get();
+            /* If we expect the data to be linkable to an existing hospital visit,
+             * search by that visit's (hl7adt) location and see that we get the same result.
+             * If not, it should be empty.
+             * Is this repo query even useful? Might want to add time interval to it.
+             */
+            List<Waveform> byHl7AdtLocation = filterByDatetimeInterval(
+                    waveformRepository.findAllByLocationOrderByObservationDatetime(test.location),
+                    test.obsDatetime,
+                    test.getEndObsTime());
+
+            if (test.expectedLocationVisitId == null) {
+                assertTrue(waveformRows.stream().allMatch(aw -> aw.getLocationVisitId() == null));
+                assertTrue(byHl7AdtLocation.isEmpty());
+            } else {
+                assertTrue(waveformRows.stream().allMatch(aw -> aw.getLocationVisitId().getLocationVisitId() == test.expectedLocationVisitId));
+
+                // .equals does not work properly for our Entities, but we only need to check that it's
+                // the same rows, so just check PKs
+                Set<Long> idsByHl7Adt = byHl7AdtLocation.stream().map(Waveform::getWaveformId).collect(Collectors.toSet());
+                Set<Long> idsBySource = waveformRows.stream().map(Waveform::getWaveformId).collect(Collectors.toSet());
+                assertEquals(idsByHl7Adt, idsBySource);
+            }
             List<Double> actualDataPointsAtLocation = new ArrayList<>();
-            for (var row : actualWaveformsAtLocation) {
+            for (var row: waveformRows) {
                 assertTrue(row.getValuesArray().length <= test.maxSamplesPerMessage);
                 actualDataPointsAtLocation.addAll(Arrays.asList(row.getValuesArray()));
             }
@@ -96,7 +140,7 @@ class TestWaveformProcessing extends MessageProcessingBase {
                 assertNotEquals(thisValue, previousValue);
             }
             Instant projectedEndTime = null;
-            for (var row : actualWaveformsAtLocation) {
+            for (var row : waveformRows) {
                 Instant thisStartTime = row.getObservationDatetime();
                 if (projectedEndTime != null) {
                     // rows should neatly abut
@@ -109,9 +153,21 @@ class TestWaveformProcessing extends MessageProcessingBase {
                         ChronoUnit.MICROS);
             }
             long totalExpectedTimeMicros = 1_000_000L * test.numSamples / test.samplingRate;
-            long totalActualTimeMicros = actualWaveformsAtLocation.get(0).getObservationDatetime().until(projectedEndTime, ChronoUnit.MICROS);
+            long totalActualTimeMicros = waveformRows.get(0).getObservationDatetime().until(projectedEndTime, ChronoUnit.MICROS);
             assertEquals(totalExpectedTimeMicros, totalActualTimeMicros);
         }
+        assertEquals(Arrays.stream(allTests).map(d -> d.numSamples).reduce(Integer::sum).get(), totalObservedNumSamples);
+    }
+
+    private static List<Waveform> filterByDatetimeInterval(Iterable<Waveform> waveforms, Instant beginTime, Instant endTime) {
+        List<Waveform> filteredRows = new ArrayList<>();
+        for (var waveform: waveforms) {
+            if (waveform.getObservationDatetime().compareTo(beginTime) >= 0
+                    && waveform.getObservationDatetime().compareTo(endTime) < 0) {
+                filteredRows.add(waveform);
+            }
+        }
+        return filteredRows;
     }
 
 }

--- a/emap-interchange/src/main/java/uk/ac/ucl/rits/inform/interchange/visit_observations/WaveformMessage.java
+++ b/emap-interchange/src/main/java/uk/ac/ucl/rits/inform/interchange/visit_observations/WaveformMessage.java
@@ -24,7 +24,31 @@ import java.util.List;
 public class WaveformMessage extends EmapOperationMessage {
     private String sourceObservationType = "waveform";
 
-    private String locationString;
+    /**
+     * Time of the observation.
+     */
+    private Instant observationTime;
+
+    /**
+     * Location string according to the original data source.
+     */
+    private String sourceLocationString;
+
+    /**
+     * Location string, mapped by the data source to the canonical Emap format,
+     * which matches what we get from the main HL7 ADT feed.
+     */
+    private String mappedLocationString;
+
+    /**
+     * Stream ID according to the source system.
+     */
+    private String sourceStreamId;
+
+    /**
+     * Stream description mapped by the data source.
+     */
+    private String mappedStreamDescription;
 
     /**
      * Sampling rate in Hz.
@@ -35,11 +59,6 @@ public class WaveformMessage extends EmapOperationMessage {
      * Numeric value.
      */
     private InterchangeValue<List<Double>> numericValues = InterchangeValue.unknown();
-
-    /**
-     * Time of the observation.
-     */
-    private Instant observationTime;
 
     /**
      * Call back to the processor so it knows what type this object is (ie. double dispatch).

--- a/emap-interchange/src/test/java/uk/ac/ucl/rits/inform/interchange/test/helpers/InterchangeMessageFactory.java
+++ b/emap-interchange/src/test/java/uk/ac/ucl/rits/inform/interchange/test/helpers/InterchangeMessageFactory.java
@@ -260,11 +260,14 @@ public class InterchangeMessageFactory {
      * @param samplingRate samples per second
      * @param numSamples total bumber of samples to generate
      * @param maxSamplesPerMessage how many samples to put in a message; split as necessary
-     * @param location bed location
+     * @param sourceLocation bed location according to the original data
+     * @param mappedLocation bed location according to data reader's interpretation of the original data
      * @param obsDatetime when the data occurred
      * @return list of messages containing synthetic data
      */
-    public List<WaveformMessage> getWaveformMsgs(String sourceStreamId, long samplingRate, final int numSamples, int maxSamplesPerMessage, String location, Instant obsDatetime) {
+    public List<WaveformMessage> getWaveformMsgs(String sourceStreamId, long samplingRate, final int numSamples,
+                                                 int maxSamplesPerMessage, String sourceLocation, String mappedLocation,
+                                                 Instant obsDatetime) {
         // XXX: perhaps make use of the hl7-reader utility function for splitting messages? Or is that cheating?
         // Or should such a utility function go into (non-test) Interchange?
         List<WaveformMessage> allMessages = new ArrayList<>();
@@ -275,8 +278,8 @@ public class InterchangeMessageFactory {
             waveformMessage.setSourceStreamId(sourceStreamId);
             waveformMessage.setSamplingRate(samplingRate);
             // XXX: need the actual source string
-            waveformMessage.setSourceLocationString(location);
-            waveformMessage.setMappedLocationString(location);
+            waveformMessage.setSourceLocationString(sourceLocation);
+            waveformMessage.setMappedLocationString(mappedLocation);
             var values = new ArrayList<Double>();
             for (int i = 0; i < samplesThisMessage; i++) {
                 values.add(Math.sin(i * 0.01));

--- a/emap-interchange/src/test/java/uk/ac/ucl/rits/inform/interchange/test/helpers/InterchangeMessageFactory.java
+++ b/emap-interchange/src/test/java/uk/ac/ucl/rits/inform/interchange/test/helpers/InterchangeMessageFactory.java
@@ -257,6 +257,8 @@ public class InterchangeMessageFactory {
 
     /**
      *
+     * @param sourceStreamId how the source data identifies this stream
+     * @param mappedStreamName how the reader has interpreted the source stream id
      * @param samplingRate samples per second
      * @param numSamples total bumber of samples to generate
      * @param maxSamplesPerMessage how many samples to put in a message; split as necessary
@@ -265,8 +267,9 @@ public class InterchangeMessageFactory {
      * @param obsDatetime when the data occurred
      * @return list of messages containing synthetic data
      */
-    public List<WaveformMessage> getWaveformMsgs(String sourceStreamId, long samplingRate, final int numSamples,
-                                                 int maxSamplesPerMessage, String sourceLocation, String mappedLocation,
+    public List<WaveformMessage> getWaveformMsgs(String sourceStreamId, String mappedStreamName,
+                                                 long samplingRate, final int numSamples, int maxSamplesPerMessage,
+                                                 String sourceLocation, String mappedLocation,
                                                  Instant obsDatetime) {
         // XXX: perhaps make use of the hl7-reader utility function for splitting messages? Or is that cheating?
         // Or should such a utility function go into (non-test) Interchange?
@@ -276,8 +279,8 @@ public class InterchangeMessageFactory {
             int samplesThisMessage = Math.min(samplesRemaining, maxSamplesPerMessage);
             WaveformMessage waveformMessage = new WaveformMessage();
             waveformMessage.setSourceStreamId(sourceStreamId);
+            waveformMessage.setMappedStreamDescription(mappedStreamName);
             waveformMessage.setSamplingRate(samplingRate);
-            // XXX: need the actual source string
             waveformMessage.setSourceLocationString(sourceLocation);
             waveformMessage.setMappedLocationString(mappedLocation);
             var values = new ArrayList<Double>();

--- a/emap-interchange/src/test/java/uk/ac/ucl/rits/inform/interchange/test/helpers/InterchangeMessageFactory.java
+++ b/emap-interchange/src/test/java/uk/ac/ucl/rits/inform/interchange/test/helpers/InterchangeMessageFactory.java
@@ -261,12 +261,12 @@ public class InterchangeMessageFactory {
      * @param numSamples total bumber of samples to generate
      * @param maxSamplesPerMessage how many samples to put in a message; split as necessary
      * @param location bed location
+     * @param obsDatetime when the data occurred
      * @return list of messages containing synthetic data
      */
-    public List<WaveformMessage> getWaveformMsgs(int samplingRate, final int numSamples, int maxSamplesPerMessage, String location) {
+    public List<WaveformMessage> getWaveformMsgs(long samplingRate, final int numSamples, int maxSamplesPerMessage, String location, Instant obsDatetime) {
         // XXX: perhaps make use of the hl7-reader utility function for splitting messages? Or is that cheating?
         // Or should such a utility function go into (non-test) Interchange?
-        Instant thisMessageTime = Instant.parse("2020-01-01T01:02:03Z");
         List<WaveformMessage> allMessages = new ArrayList<>();
         int samplesRemaining = numSamples;
         while (samplesRemaining > 0) {
@@ -279,10 +279,10 @@ public class InterchangeMessageFactory {
                 values.add(Math.sin(i * 0.01));
             }
             waveformMessage.setNumericValues(new InterchangeValue<>(values));
-            waveformMessage.setObservationTime(thisMessageTime);
+            waveformMessage.setObservationTime(obsDatetime);
             allMessages.add(waveformMessage);
             samplesRemaining -= samplesThisMessage;
-            thisMessageTime = thisMessageTime.plus(samplesThisMessage * 1000_000 / samplingRate, ChronoUnit.MICROS);
+            obsDatetime = obsDatetime.plus(samplesThisMessage * 1000_000 / samplingRate, ChronoUnit.MICROS);
         }
         return allMessages;
     }

--- a/emap-interchange/src/test/java/uk/ac/ucl/rits/inform/interchange/test/helpers/InterchangeMessageFactory.java
+++ b/emap-interchange/src/test/java/uk/ac/ucl/rits/inform/interchange/test/helpers/InterchangeMessageFactory.java
@@ -264,7 +264,7 @@ public class InterchangeMessageFactory {
      * @param obsDatetime when the data occurred
      * @return list of messages containing synthetic data
      */
-    public List<WaveformMessage> getWaveformMsgs(long samplingRate, final int numSamples, int maxSamplesPerMessage, String location, Instant obsDatetime) {
+    public List<WaveformMessage> getWaveformMsgs(String sourceStreamId, long samplingRate, final int numSamples, int maxSamplesPerMessage, String location, Instant obsDatetime) {
         // XXX: perhaps make use of the hl7-reader utility function for splitting messages? Or is that cheating?
         // Or should such a utility function go into (non-test) Interchange?
         List<WaveformMessage> allMessages = new ArrayList<>();
@@ -272,8 +272,11 @@ public class InterchangeMessageFactory {
         while (samplesRemaining > 0) {
             int samplesThisMessage = Math.min(samplesRemaining, maxSamplesPerMessage);
             WaveformMessage waveformMessage = new WaveformMessage();
+            waveformMessage.setSourceStreamId(sourceStreamId);
             waveformMessage.setSamplingRate(samplingRate);
-            waveformMessage.setLocationString(location);
+            // XXX: need the actual source string
+            waveformMessage.setSourceLocationString(location);
+            waveformMessage.setMappedLocationString(location);
             var values = new ArrayList<Double>();
             for (int i = 0; i < samplesThisMessage; i++) {
                 values.add(Math.sin(i * 0.01));

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/Waveform.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/Waveform.java
@@ -122,6 +122,7 @@ public class Waveform extends TemporalCore<Waveform, WaveformAudit> {
     public Waveform(Waveform other) {
         super(other);
         this.waveformId = other.waveformId;
+        this.visitObservationTypeId = other.visitObservationTypeId;
         this.locationVisitId = other.locationVisitId;
         this.valuesArray = other.valuesArray;
         this.observationDatetime = other.observationDatetime;

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/Waveform.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/Waveform.java
@@ -53,9 +53,9 @@ public class Waveform extends TemporalCore<Waveform, WaveformAudit> {
      *
      * This is a foreign key that joins the visitObservation table to the VisitObservationType table.
      */
-//    @ManyToOne
-//    @JoinColumn(name = "visitObservationTypeId", nullable = false)
-//    private VisitObservationType visitObservationTypeId;
+    @ManyToOne
+    @JoinColumn(name = "visitObservationTypeId", nullable = false)
+    private VisitObservationType visitObservationTypeId;
 
     /**
      * \brief Identifier for the LocationVisit associated with this record.

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/Waveform.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/Waveform.java
@@ -6,6 +6,7 @@ import lombok.ToString;
 import org.hibernate.annotations.Type;
 import uk.ac.ucl.rits.inform.informdb.TemporalCore;
 import uk.ac.ucl.rits.inform.informdb.annotation.AuditTable;
+import uk.ac.ucl.rits.inform.informdb.movement.LocationVisit;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
@@ -15,6 +16,8 @@ import javax.persistence.Id;
 import javax.persistence.Index;
 import javax.persistence.Inheritance;
 import javax.persistence.InheritanceType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 import java.time.Instant;
 
@@ -26,7 +29,8 @@ import java.time.Instant;
 @Entity
 @Table(indexes = {
         @Index(name = "waveform_datetime", columnList = "observationDatetime"),
-        @Index(name = "waveform_location", columnList = "location"),
+        @Index(name = "waveform_location", columnList = "sourceLocation"),
+        @Index(name = "waveform_location_visit", columnList = "locationVisitId"),
 })
 @Data
 @EqualsAndHashCode(callSuper = true)
@@ -36,9 +40,9 @@ import java.time.Instant;
 public class Waveform extends TemporalCore<Waveform, WaveformAudit> {
 
     /**
-     * \brief Unique identifier in EMAP for this visitObservation record.
+     * \brief Unique identifier for this record.
      *
-     * This is the primary key for the visitObservation table.
+     * This is the primary key.
      */
     @Id
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "waveform_id_sequence")
@@ -54,13 +58,13 @@ public class Waveform extends TemporalCore<Waveform, WaveformAudit> {
 //    private VisitObservationType visitObservationTypeId;
 
     /**
-     * \brief Identifier for the HospitalVisit associated with this record.
+     * \brief Identifier for the LocationVisit associated with this record.
      *
-     * This is a foreign key that joins the visitObservation table to the HospitalVisit table.
+     * If it is null, this data is said to be orphaned.
      */
-//    @ManyToOne
-//    @JoinColumn(name = "hospitalVisitId", nullable = false)
-//    private HospitalVisit hospitalVisitId;
+    @ManyToOne
+    @JoinColumn(name = "locationVisitId")
+    private LocationVisit locationVisitId;
 
     /**
      * \brief Date and time at which this visitObservation was first made.
@@ -71,9 +75,16 @@ public class Waveform extends TemporalCore<Waveform, WaveformAudit> {
     @Column(columnDefinition = "timestamp with time zone", nullable = false)
     private Instant observationDatetime;
 
+    @Column(nullable = false)
     private long samplingRate;
 
-    private String location;
+    /**
+     * \brief Location according to the source system.
+     * This will always be known,
+     * and must be kept in case this data needs to be de-orphaned later.
+     */
+    @Column(nullable = false)
+    private String sourceLocation;
 
     /**
      * \brief Value as a floating point array.
@@ -111,10 +122,11 @@ public class Waveform extends TemporalCore<Waveform, WaveformAudit> {
     public Waveform(Waveform other) {
         super(other);
         this.waveformId = other.waveformId;
+        this.locationVisitId = other.locationVisitId;
         this.valuesArray = other.valuesArray;
         this.observationDatetime = other.observationDatetime;
         this.samplingRate = other.samplingRate;
-        this.location = other.location;
+        this.sourceLocation = other.sourceLocation;
     }
 
     @Override

--- a/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/Hl7ParseAndSend.java
+++ b/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/Hl7ParseAndSend.java
@@ -41,7 +41,8 @@ public class Hl7ParseAndSend {
 
         WaveformMessage waveformMessage = new WaveformMessage();
         waveformMessage.setSamplingRate(Long.parseLong(samplingRateStr));
-        waveformMessage.setLocationString(locationId);
+        waveformMessage.setSourceLocationString(locationId);
+        // XXX: need to perform location mapping here and set the mapped location
         waveformMessage.setObservationTime(Instant.parse(messageStartTimeStr));
         waveformMessage.setSourceMessageId(messageId);
         String[] valuesArray = valuesStr.split(",");


### PR DESCRIPTION
Implements #35 

Find the location visit from the time and place associated with the waveform data, as this information is not given to us directly.

Pass both original (source) and interpreted (mapped) location strings to the core proc. Mapped location string is used to look up the location visit and ultimately to find out who the patient is.

Pass both original (source) and interpreted (mapped) stream description strings to the core proc, which stores them as an Visit Observation Type.