### PR TITLE
Collate messages

### DIFF
--- a/core/src/test/java/uk/ac/ucl/rits/inform/datasinks/emapstar/waveform/TestWaveformProcessing.java
+++ b/core/src/test/java/uk/ac/ucl/rits/inform/datasinks/emapstar/waveform/TestWaveformProcessing.java
@@ -161,9 +161,6 @@ class TestWaveformProcessing extends MessageProcessingBase {
         assertEquals(Arrays.stream(allTests).map(d -> d.numSamples).reduce(Integer::sum).get(), totalObservedNumSamples);
         // XXX: do more with this
         List<VisitObservationType> allWaveformVO = visitObservationTypeRepository.findAllBySourceObservationType("waveform");
-        for (var vo: allWaveformVO) {
-            System.out.println("JES: " + vo.toString());
-        }
         assertEquals(2, allWaveformVO.size());
     }
 

--- a/core/src/test/java/uk/ac/ucl/rits/inform/datasinks/emapstar/waveform/TestWaveformProcessing.java
+++ b/core/src/test/java/uk/ac/ucl/rits/inform/datasinks/emapstar/waveform/TestWaveformProcessing.java
@@ -81,7 +81,7 @@ class TestWaveformProcessing extends MessageProcessingBase {
             allMessages.addAll(
                     messageFactory.getWaveformMsgs(test.sourceStreamId, test.mappedStreamName,
                             test.samplingRate, test.numSamples, test.maxSamplesPerMessage, test.sourceLocation,
-                            test.mappedLocation, test.obsDatetime));
+                            test.mappedLocation, test.obsDatetime, null));
         }
 
         // must cope with messages in any order! Fixed seed to aid in debugging.

--- a/emap-interchange/src/main/java/uk/ac/ucl/rits/inform/interchange/utils/DateTimeUtils.java
+++ b/emap-interchange/src/main/java/uk/ac/ucl/rits/inform/interchange/utils/DateTimeUtils.java
@@ -1,0 +1,32 @@
+package uk.ac.ucl.rits.inform.interchange.utils;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+
+/**
+ * Utility functions for manipulating timestamps etc.
+ */
+public final class DateTimeUtils {
+    private DateTimeUtils() {}
+
+    /**
+     * Round Instant to the nearest time unit using normal convention of halfway rounds up.
+     * @param obsDatetime Instant to round
+     * @param roundToUnit what ChronoUnit to round to, or null to return the original timestamp
+     * @return the rounded Instant
+     */
+    public static Instant roundInstantToNearest(Instant obsDatetime, ChronoUnit roundToUnit) {
+        if (roundToUnit == null) {
+            return obsDatetime;
+        }
+        // determine whether to round up or down
+        Instant roundedDown = obsDatetime.truncatedTo(roundToUnit);
+        Instant roundedUp = obsDatetime.plus(1, roundToUnit).truncatedTo(roundToUnit);
+        if (obsDatetime.until(roundedUp, ChronoUnit.NANOS) > roundedDown.until(obsDatetime, ChronoUnit.NANOS)) {
+            return roundedDown;
+        } else {
+            return roundedUp;
+        }
+    }
+
+}

--- a/emap-interchange/src/main/java/uk/ac/ucl/rits/inform/interchange/utils/DateTimeUtils.java
+++ b/emap-interchange/src/main/java/uk/ac/ucl/rits/inform/interchange/utils/DateTimeUtils.java
@@ -11,18 +11,18 @@ public final class DateTimeUtils {
 
     /**
      * Round Instant to the nearest time unit using normal convention of halfway rounds up.
-     * @param obsDatetime Instant to round
+     * @param instant Instant to round
      * @param roundToUnit what ChronoUnit to round to, or null to return the original timestamp
      * @return the rounded Instant
      */
-    public static Instant roundInstantToNearest(Instant obsDatetime, ChronoUnit roundToUnit) {
+    public static Instant roundInstantToNearest(Instant instant, ChronoUnit roundToUnit) {
         if (roundToUnit == null) {
-            return obsDatetime;
+            return instant;
         }
         // determine whether to round up or down
-        Instant roundedDown = obsDatetime.truncatedTo(roundToUnit);
-        Instant roundedUp = obsDatetime.plus(1, roundToUnit).truncatedTo(roundToUnit);
-        if (obsDatetime.until(roundedUp, ChronoUnit.NANOS) > roundedDown.until(obsDatetime, ChronoUnit.NANOS)) {
+        Instant roundedDown = instant.truncatedTo(roundToUnit);
+        Instant roundedUp = instant.plus(1, roundToUnit).truncatedTo(roundToUnit);
+        if (instant.until(roundedUp, ChronoUnit.NANOS) > roundedDown.until(instant, ChronoUnit.NANOS)) {
             return roundedDown;
         } else {
             return roundedUp;

--- a/emap-interchange/src/main/java/uk/ac/ucl/rits/inform/interchange/utils/package-info.java
+++ b/emap-interchange/src/main/java/uk/ac/ucl/rits/inform/interchange/utils/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Utility code related to interchange messages, possibly quite loosely.
+ */
+package uk.ac.ucl.rits.inform.interchange.utils;

--- a/emap-interchange/src/main/java/uk/ac/ucl/rits/inform/interchange/visit_observations/WaveformMessage.java
+++ b/emap-interchange/src/main/java/uk/ac/ucl/rits/inform/interchange/visit_observations/WaveformMessage.java
@@ -1,5 +1,6 @@
 package uk.ac.ucl.rits.inform.interchange.visit_observations;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -65,6 +66,7 @@ public class WaveformMessage extends EmapOperationMessage {
      * @return expected observation datetime for the next message, if it exists and there are
      * no gaps between messages
      */
+    @JsonIgnore
     public Instant getExpectedNextObservationDatetime() {
         int numValues = numericValues.get().size();
         long microsToAdd = 1_000_000L * numValues / samplingRate;

--- a/emap-interchange/src/main/java/uk/ac/ucl/rits/inform/interchange/visit_observations/WaveformMessage.java
+++ b/emap-interchange/src/main/java/uk/ac/ucl/rits/inform/interchange/visit_observations/WaveformMessage.java
@@ -10,6 +10,7 @@ import uk.ac.ucl.rits.inform.interchange.EmapOperationMessageProcessor;
 import uk.ac.ucl.rits.inform.interchange.InterchangeValue;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 
 /**
@@ -59,6 +60,16 @@ public class WaveformMessage extends EmapOperationMessage {
      * Numeric value.
      */
     private InterchangeValue<List<Double>> numericValues = InterchangeValue.unknown();
+
+    /**
+     * @return expected observation datetime for the next message, if it exists and there are
+     * no gaps between messages
+     */
+    public Instant getExpectedNextObservationDatetime() {
+        int numValues = numericValues.get().size();
+        long microsToAdd = 1_000_000L * numValues / samplingRate;
+        return observationTime.plus(microsToAdd, ChronoUnit.MICROS);
+    }
 
     /**
      * Call back to the processor so it knows what type this object is (ie. double dispatch).

--- a/waveform-generator/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform_generator/Hl7Generator.java
+++ b/waveform-generator/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform_generator/Hl7Generator.java
@@ -214,8 +214,8 @@ public class Hl7Generator {
         List<String> waveformMsgs = new ArrayList<>();
         for (int p = 0; p < numPatients; p++) {
             var location = String.format("Bed%03d", p);
-            String streamId1 = "52912";
-            String streamId2 = "52913";
+            String streamId1 = "59912";
+            String streamId2 = "59913";
             int sizeBefore = waveformMsgs.size();
             waveformMsgs.addAll(makeSyntheticWaveformMsgs(
                     location, streamId1, 50, numMillis, startTime, 5));
@@ -226,9 +226,6 @@ public class Hl7Generator {
         }
 
         return waveformMsgs;
-
     }
-
-
 
 }

--- a/waveform-generator/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform_generator/Hl7Generator.java
+++ b/waveform-generator/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform_generator/Hl7Generator.java
@@ -164,7 +164,7 @@ public class Hl7Generator {
      * @param samplingRate in samples per second
      * @param numMillis number of milliseconds to produce data for
      * @param startTime observation time of the beginning of the period that the messages are to cover
-     * @param millisPerMessage max time per message (will split into multiple if needed)
+     * @param maxSamplesPerMessage max samples per message (will split into multiple messages if needed)
      * @return all messages
      */
     private List<String> makeSyntheticWaveformMsgs(final String locationId,
@@ -172,7 +172,7 @@ public class Hl7Generator {
                                                    final long samplingRate,
                                                    final long numMillis,
                                                    final Instant startTime,
-                                                   final long millisPerMessage
+                                                   final long maxSamplesPerMessage
     ) {
         List<String> allMessages = new ArrayList<>();
         final long numSamples = numMillis * samplingRate / 1000;
@@ -184,9 +184,8 @@ public class Hl7Generator {
             String messageId = String.format("%s_t%s_msg%05d", locationId, timeStr, overallSampleIdx);
 
             var values = new ArrayList<Double>();
-            long samplesPerMessage = samplingRate * millisPerMessage / 1000;
             for (long valueIdx = 0;
-                 valueIdx < samplesPerMessage && overallSampleIdx < numSamples;
+                 valueIdx < maxSamplesPerMessage && overallSampleIdx < numSamples;
                  valueIdx++, overallSampleIdx++) {
                 // a sine wave between maxValue and -maxValue
                 values.add(2 * maxValue * Math.sin(overallSampleIdx * 0.01) - maxValue);
@@ -217,12 +216,11 @@ public class Hl7Generator {
             var location = String.format("Bed%03d", p);
             String streamId1 = "52912";
             String streamId2 = "52913";
-            final long millisPerMessage = 10000;
             int sizeBefore = waveformMsgs.size();
             waveformMsgs.addAll(makeSyntheticWaveformMsgs(
-                    location, streamId1, 50, numMillis, startTime, millisPerMessage));
+                    location, streamId1, 50, numMillis, startTime, 5));
             waveformMsgs.addAll(makeSyntheticWaveformMsgs(
-                    location, streamId2, 300, numMillis, startTime, millisPerMessage));
+                    location, streamId2, 300, numMillis, startTime, 10));
             int sizeAfter = waveformMsgs.size();
             logger.debug("Patient {}, generated {} messages", p, sizeAfter - sizeBefore);
         }

--- a/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/Application.java
+++ b/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/Application.java
@@ -4,7 +4,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.scheduling.annotation.EnableScheduling;
 
 /**
  * Spring application entry point.
@@ -14,7 +13,6 @@ import org.springframework.scheduling.annotation.EnableScheduling;
         "uk.ac.ucl.rits.inform.datasources.waveform",
         "uk.ac.ucl.rits.inform.interchange",
         })
-@EnableScheduling
 public class Application {
     private final Logger logger = LoggerFactory.getLogger(Application.class);
 
@@ -24,7 +22,6 @@ public class Application {
     public static void main(String[] args) {
         SpringApplication.run(Application.class, args);
     }
-
 
 
 }

--- a/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/Hl7ListenerConfig.java
+++ b/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/Hl7ListenerConfig.java
@@ -88,14 +88,14 @@ public class Hl7ListenerConfig {
     /**
      * Message handler. Source IP check has passed if we get here. No reply is expected.
      * @param msg the incoming message
-     * @throws InterruptedException if publisher send is interrupted
-     * @throws Hl7ParseException .
+     * @throws Hl7ParseException if HL7 is invalid or in a form that the ad hoc parser can't handle
+     * @throws WaveformCollator.CollationException if the data has a logical error that prevents collation
      */
     @ServiceActivator(inputChannel = "hl7Stream")
-    public void handler(Message<byte[]> msg) throws InterruptedException, Hl7ParseException {
+    public void handler(Message<byte[]> msg) throws Hl7ParseException, WaveformCollator.CollationException {
         byte[] asBytes = msg.getPayload();
         String asStr = new String(asBytes, StandardCharsets.UTF_8);
-        // parse message from HL7 to interchange message, send to publisher
-        hl7ParseAndSend.parseAndSend(asStr);
+        // parse message from HL7 to interchange message, send to internal queue
+        hl7ParseAndSend.parseAndQueue(asStr);
     }
 }

--- a/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/SchedulingConfig.java
+++ b/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/SchedulingConfig.java
@@ -1,0 +1,14 @@
+package uk.ac.ucl.rits.inform.datasources.waveform;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.scheduling.annotation.EnableScheduling;
+
+/**
+ * Scheduling only to be enabled when not running unit tests.
+ */
+@Configuration
+@EnableScheduling
+@Profile("!test")
+public class SchedulingConfig {
+}

--- a/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/WaveformCollator.java
+++ b/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/WaveformCollator.java
@@ -228,8 +228,9 @@ public class WaveformCollator {
          */
         logger.trace("expectedNextDatetime {}, expectedNextDatetimeRounded {}, msg.getObservationTime() {}",
                 expectedNextDatetime, expectedNextDatetimeRounded, msg.getObservationTime());
-        long allowedGapMicros = 1000;
-    //                double allowedGapMicros = samplePeriodMicros * 0.05;
+
+        // if it has been rounded to the millisecond, allow it to be one millisecond out, and so on
+        long allowedGapMicros = assumedRounding.getDuration().toNanos() / 1000;
         if (Math.abs(gapSizeMicros) > allowedGapMicros && Math.abs(gapSizeToRoundedMicros) > allowedGapMicros) {
             logger.info("Key {}, Gap too big ({} microsecs vs rounded, {} vs unrounded)",
                     makeKey(msg), gapSizeToRoundedMicros, gapSizeMicros);

--- a/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/WaveformCollator.java
+++ b/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/WaveformCollator.java
@@ -1,0 +1,138 @@
+package uk.ac.ucl.rits.inform.datasources.waveform;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import uk.ac.ucl.rits.inform.interchange.InterchangeValue;
+import uk.ac.ucl.rits.inform.interchange.visit_observations.WaveformMessage;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.SortedMap;
+import java.util.TreeMap;
+
+@Component
+public class WaveformCollator {
+    private final Logger logger = LoggerFactory.getLogger(WaveformCollator.class);
+    private final Map<Pair<String, String>, SortedMap<Instant, WaveformMessage>> pendingMessages = new HashMap<>();
+
+    private Pair<String, String> makeKey(WaveformMessage msg) {
+        return new ImmutablePair<>(msg.getSourceLocationString(), msg.getSourceStreamId());
+    }
+
+    /**
+     * Add short messages from the same patient for collating.
+     * @param messagesToAdd messages to add, must all be for same patient
+     */
+    public void addMessages(List<WaveformMessage> messagesToAdd) {
+        /*
+         * Will probably need per-patient locks otherwise the threads won't be able to do much.
+         * But that will complicate iterating.
+         */
+        synchronized (this) {
+            for (var msg : messagesToAdd) {
+                // can we optimise on the basis that all messages in the list will have the same key?
+                Pair<String, String> messageKey = makeKey(msg);
+                SortedMap<Instant, WaveformMessage> existingMessages = pendingMessages.computeIfAbsent(
+                        messageKey, k -> new TreeMap<>());
+                Instant observationTime = msg.getObservationTime();
+                // messages may arrive out of order, but TreeMap will keep them sorted by obs time
+                existingMessages.put(observationTime, msg);
+            }
+        }
+    }
+
+    /**
+     * If a sufficient run of gapless messages exists for a patient, collate them
+     * and delete the source messages.
+     * @return the collated messages that are now ready for sending
+     */
+    public List<WaveformMessage> getReadyMessages() {
+        final long minimumSpanMillis = 10000;
+        List<WaveformMessage> newMessages = new ArrayList<>();
+        synchronized (this) {
+            for (SortedMap<Instant, WaveformMessage> perPatientMap: pendingMessages.values()) {
+                Instant earliestDatetime = perPatientMap.firstKey();
+                Instant latestDatetime = perPatientMap.lastKey();
+                long spanMillis = earliestDatetime.until(latestDatetime, ChronoUnit.MILLIS);
+                if (spanMillis < minimumSpanMillis) {
+                    continue;
+                }
+                // even if we've achieved a certain span, there may still be gaps!
+                Instant noGapsUntil = checkForGaps(perPatientMap.values());
+                WaveformMessage newMsg;
+                if (noGapsUntil == null) {
+                    newMsg = collate(perPatientMap, earliestDatetime.plus(minimumSpanMillis, ChronoUnit.MILLIS));
+                } else {
+                    newMsg = collate(perPatientMap, noGapsUntil);
+                }
+                newMessages.add(newMsg);
+            }
+        }
+        return newMessages;
+    }
+
+    private WaveformMessage collate(SortedMap<Instant, WaveformMessage> perPatientMap,
+                                    Instant upperLimit) {
+        WaveformMessage firstMsg = perPatientMap.get(perPatientMap.firstKey());
+
+        int sizeBefore = perPatientMap.size();
+        Iterator<Map.Entry<Instant, WaveformMessage>> entryIter = perPatientMap.entrySet().iterator();
+        long totalPointsSummed = firstMsg.getNumericValues().get().size();
+        // existing values are not necessarily mutable so use a new ArrayList
+        List<Double> newNumericValues = new ArrayList<>();
+        while (entryIter.hasNext()) {
+            Map.Entry<Instant, WaveformMessage> entry = entryIter.next();
+            Instant k = entry.getKey();
+            WaveformMessage msg = entry.getValue();
+            newNumericValues.addAll(msg.getNumericValues().get());
+            if (k.compareTo(upperLimit) >= 0) {
+                logger.info("Reached upper limit {}", upperLimit);
+                break;
+            }
+            totalPointsSummed += msg.getNumericValues().get().size();
+            // Remove all Map entries up to the upper limit, even the first one.
+            // We still want the underlying object of the first element to exist.
+            entryIter.remove();
+        }
+        firstMsg.setNumericValues(new InterchangeValue<>(newNumericValues));
+        int sizeAfter = perPatientMap.size();
+        if (totalPointsSummed != firstMsg.getNumericValues().get().size()) {
+            throw new RuntimeException(String.format("Oh dear, should be %d entries, got %d",
+                    totalPointsSummed, firstMsg.getNumericValues().get().size()));
+        }
+        logger.info("Collated {} messages into one, ({} data points)", sizeBefore - sizeAfter, totalPointsSummed);
+        return firstMsg;
+    }
+
+    /**
+     * @param allMessages list of sorted messages to check for gaps in
+     * @return null if no gaps, or if gaps the (exclusive) datetime limit before which there are no gaps
+     */
+    private Instant checkForGaps(Collection<WaveformMessage> allMessages) {
+        Instant expectedNextDatetime = null;
+        for (WaveformMessage msg: allMessages) {
+            if (expectedNextDatetime != null) {
+                // gap between this message and previous message
+                long samplePeriodMicros = 1_000_000L / msg.getSamplingRate();
+                long gapSizeMicros = expectedNextDatetime.until(msg.getObservationTime(), ChronoUnit.MICROS);
+                // some rounding error is likely, but let's say for now that anything
+                // less than 10% of a sample period is a good enough score to just join them together
+                if (Math.abs(gapSizeMicros) > samplePeriodMicros / 10) {
+                    logger.info("Gap too big ({} microsecs), skipping for now", gapSizeMicros);
+                    return msg.getObservationTime();
+                }
+            }
+            expectedNextDatetime = msg.getExpectedNextObservationDatetime();
+        }
+        return null;
+    }
+}

--- a/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/WaveformOperations.java
+++ b/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/WaveformOperations.java
@@ -17,14 +17,20 @@ public class WaveformOperations {
     }
 
 
-    private void publishMessage(Publisher publisher, String messageId, WaveformMessage m) throws InterruptedException {
-        publisher.submit(m, messageId, messageId, () -> {
+    /**
+     * Send message to rabbitmq.
+     * @param msg the (collated) waveform message
+     * @throws InterruptedException If the Publisher thread is interrupted
+     */
+    public void sendMessage(WaveformMessage msg) throws InterruptedException {
+        if (msg.getSourceMessageId() == null || msg.getSourceMessageId().isEmpty()) {
+            logger.error("ERROR: About to publish message with bad message ID {}", msg.getSourceMessageId());
+        }
+        String messageId = msg.getSourceMessageId();
+        publisher.submit(msg, messageId, messageId, () -> {
+            // XXX: If/when we find a way of re-requesting old messages, we may want to keep track of progress here
+            // See issue #40.
             logger.debug("Successful ACK for message with ID {}", messageId);
         });
-    }
-
-
-    public void sendMessage(WaveformMessage msg) throws InterruptedException {
-        publishMessage(publisher, msg.getSourceMessageId(), msg);
     }
 }

--- a/waveform-reader/src/test/java/uk/ac/ucl/rits/inform/datasources/waveform/TestHl7ParseAndSend.java
+++ b/waveform-reader/src/test/java/uk/ac/ucl/rits/inform/datasources/waveform/TestHl7ParseAndSend.java
@@ -22,7 +22,6 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SpringJUnitConfig
-@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
 @SpringBootTest
 @ActiveProfiles("test")
 class TestHl7ParseAndSend {

--- a/waveform-reader/src/test/java/uk/ac/ucl/rits/inform/datasources/waveform/TestWaveformCollation.java
+++ b/waveform-reader/src/test/java/uk/ac/ucl/rits/inform/datasources/waveform/TestWaveformCollation.java
@@ -1,0 +1,148 @@
+package uk.ac.ucl.rits.inform.datasources.waveform;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import uk.ac.ucl.rits.inform.interchange.test.helpers.InterchangeMessageFactory;
+import uk.ac.ucl.rits.inform.interchange.visit_observations.WaveformMessage;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+@SpringJUnitConfig
+@SpringBootTest
+@ActiveProfiles("test")
+public class TestWaveformCollation {
+    @Autowired
+    private Hl7ParseAndSend hl7ParseAndSend;
+    @Autowired
+    private WaveformCollator waveformCollator;
+
+    private InterchangeMessageFactory messageFactory = new InterchangeMessageFactory();
+
+    Instant messageStartDatetime = Instant.parse("2022-03-04T12:11:00Z");
+
+    @BeforeEach
+    void clearMessages() {
+        waveformCollator.pendingMessages.clear();
+    }
+
+    List<WaveformMessage> makeTestMessages() {
+        List<WaveformMessage> uncollatedMsgs = messageFactory.getWaveformMsgs(
+                "59912", "something1",
+                300, 3000, 5, "UCHT03TEST",
+                "", messageStartDatetime, ChronoUnit.MILLIS);
+        assertEquals(600, uncollatedMsgs.size());
+        return uncollatedMsgs;
+    }
+
+    private List<WaveformMessage> makeTestMessagesWithGap() {
+        List<WaveformMessage> inputMessages = makeTestMessages();
+        WaveformMessage removed = inputMessages.remove(300);
+        return inputMessages;
+    }
+
+    static Stream<Arguments> noGapsData() {
+        // We are adjusting the target number of samples config option rather than
+        // the actual number of samples supplied, which may be a bit unintuitive but
+        // amounts to the same thing.
+        return Stream.of(
+                // only just happened
+                Arguments.of(3000, 10000, 1, 0),
+                Arguments.of(3001, 10000, 0, 600),
+                Arguments.of(2995, 10000, 1, 1),
+                Arguments.of(2996, 10000, 1, 1),
+                Arguments.of(1400, 10000, 2, 40),
+                // comfortably in past
+                Arguments.of(3000, 25000, 1, 0),
+                Arguments.of(3001, 25000, 1, 0),
+                Arguments.of(2995, 25000, 2, 0),
+                Arguments.of(2996, 25000, 2, 0),
+                Arguments.of(1400, 25000, 3, 0)
+        );
+    }
+
+    // no gaps, but possible breaking into multiple messages due to sample limit
+    @ParameterizedTest
+    @MethodSource("noGapsData")
+    void noGaps(
+            int targetNumSamples,
+            int nowAfterFirstMessageMillis,
+            int expectedNewMessages,
+            int expectedRemainingMessages) throws WaveformCollator.CollationException {
+
+        int waitForDataLimitMillis = 15000;
+        ChronoUnit assumedRounding = ChronoUnit.MILLIS;
+        // GIVEN some uncollated messages (straight from HL7)
+        List<WaveformMessage> inputMessages = makeTestMessages();
+        waveformCollator.addMessages(inputMessages);
+        Pair<String, String> keyOfInterest = new ImmutablePair<>("UCHT03TEST", "59912");
+        assertEquals(1, waveformCollator.pendingMessages.size());
+        assertEquals(600, waveformCollator.pendingMessages.get(keyOfInterest).size());
+
+        // WHEN I collate the messages (which may be comfortably in the past, or have only just happened)
+        Instant now = messageStartDatetime.plus(nowAfterFirstMessageMillis, assumedRounding);
+        List<WaveformMessage> collatedMsgs = waveformCollator.getReadyMessages(
+                now, targetNumSamples, waitForDataLimitMillis, assumedRounding);
+
+        // THEN the messages have been combined into much fewer messages and the pending list is smaller or empty
+        assertEquals(expectedNewMessages, collatedMsgs.size());
+        assertEquals(expectedRemainingMessages, waveformCollator.pendingMessages.get(keyOfInterest).size());
+
+        // getting again doesn't get any more messages
+        List<WaveformMessage> collatedMsgsRepeat = waveformCollator.getReadyMessages(
+                now, targetNumSamples, waitForDataLimitMillis, assumedRounding);
+        assertEquals(0, collatedMsgsRepeat.size());
+    }
+
+    static Stream<Arguments> waitForMissingMessagesData() {
+        return Stream.of(
+                // the exact cutoff is not critical
+                Arguments.of(19999, 0),
+                Arguments.of(20001, 1),
+                Arguments.of(24999, 1),
+                Arguments.of(25001, 2)
+        );
+    }
+    @ParameterizedTest
+    @MethodSource("waitForMissingMessagesData")
+    void waitForMissingMessages( int millisAfter, int expectedSize) throws WaveformCollator.CollationException {
+        int waitForDataLimitMillis = 15000;
+        int targetCollatedMessageSamples = 3000;
+        List<WaveformMessage> inputMessages = makeTestMessagesWithGap();
+        waveformCollator.addMessages(inputMessages);
+        // We started with ~10 seconds of data, with a gap halfway. The default wait limit is 15 seconds after the gap,
+        // which is therefore 20 seconds after the first set of data, and 25 seconds after the second set.
+        Instant now = messageStartDatetime.plus(millisAfter, ChronoUnit.MILLIS);
+        List<WaveformMessage> readyMessages = waveformCollator.getReadyMessages(
+                now, targetCollatedMessageSamples, waitForDataLimitMillis, ChronoUnit.MILLIS);
+
+        // The gap means that there isn't a solid chunk of waitForDataLimitMillis of data, so nothing should have been taken out.
+        // Enough time has now passed that we should have given up on the data ever appearing, so collate it anyway.
+        // We still can't straddle the gap within a single message, so make two messages.
+        assertEquals(expectedSize, readyMessages.size());
+    }
+
+    void multipleMessagesWithMissing() {
+        // both the message size limit and a gap contribute to the multiple messages being formed.
+    }
+
+
+    void givingUpOnMissingMessages() {
+    }
+
+    void givingUpOnMissingMessagesThenDataSubsequentlyArrives() {
+    }
+
+}

--- a/waveform-reader/src/test/java/uk/ac/ucl/rits/inform/datasources/waveform/TestWaveformCollation.java
+++ b/waveform-reader/src/test/java/uk/ac/ucl/rits/inform/datasources/waveform/TestWaveformCollation.java
@@ -53,9 +53,17 @@ public class TestWaveformCollation {
     private WaveformMessage makeAndAddTestMessagesWithGap() throws WaveformCollator.CollationException {
         List<WaveformMessage> inputMessages = makeTestMessages();
         WaveformMessage removed = inputMessages.remove(300);
+        // they must work in any order
         Collections.shuffle(inputMessages, new Random(42));
         waveformCollator.addMessages(inputMessages);
         return removed;
+    }
+
+    private void makeAndAddTestMessages() throws WaveformCollator.CollationException {
+        List<WaveformMessage> inputMessages = makeTestMessages();
+        // they must work in any order
+        Collections.shuffle(inputMessages, new Random(42));
+        waveformCollator.addMessages(inputMessages);
     }
 
     static Stream<Arguments> noGapsData() {
@@ -98,9 +106,7 @@ public class TestWaveformCollation {
         int waitForDataLimitMillis = 15000;
         ChronoUnit assumedRounding = ChronoUnit.MILLIS;
         // GIVEN some uncollated messages (straight from HL7)
-        List<WaveformMessage> inputMessages = makeTestMessages();
-        Collections.shuffle(inputMessages, new Random(42));
-        waveformCollator.addMessages(inputMessages);
+        makeAndAddTestMessages();
         Pair<String, String> keyOfInterest = new ImmutablePair<>("UCHT03TEST", "59912");
         assertEquals(1, waveformCollator.pendingMessages.size());
         assertEquals(600, waveformCollator.pendingMessages.get(keyOfInterest).size());


### PR DESCRIPTION
Fixes #47 

Instead of sending Interchange messages (converted from HL7 messages) straight to the processing queue, store them in memory and wait for more to turn up so that they can be collated into one giant message, so that it can be stored efficiently in the database.
Adjust the HL7 synthetic generator to make much smaller messages, as is seen in real life.