### PR TITLE
Make containers come back at host restart

### DIFF
--- a/core/docker-compose.yml
+++ b/core/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - ../../config/core-config-envs
     logging:
       driver: "json-file"
-    restart: on-failure
+    restart: unless-stopped
     depends_on:
       glowroot-central:
         condition: service_started
@@ -25,7 +25,7 @@ services:
     ports:
       - "${RABBITMQ_PORT}:5672"
       - "${RABBITMQ_ADMIN_PORT}:15672"
-    restart: on-failure
+    restart: unless-stopped
     healthcheck:
       # rabbitmq server crashes if any rabbitmq-diagnostics cmd is run very soon
       # after starting, so can't check too aggressively here
@@ -67,6 +67,7 @@ services:
         - portal-build-secrets
     env_file:
       - ../../config/portal-config-envs
+    restart: unless-stopped
     ports:
       - "${PORTAL_PORT}:80"
 

--- a/hl7-reader/docker-compose.yml
+++ b/hl7-reader/docker-compose.yml
@@ -12,7 +12,9 @@ services:
       - ../../config/hl7-reader-config-envs
     logging:
       driver: "json-file"
-    restart: "no"
+    # This service can legitimately exit 0 when it reaches
+    # the end of its configured run, so shouldn't restart in that case.
+    restart: on-failure
     depends_on:
       # Uses services from core, orchestrate using the EMAP setup package
       - glowroot-central

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -12,4 +12,4 @@ services:
       - ../../config/streamlit-config-envs
     logging:
       driver: "json-file"
-    restart: "no"
+    restart: unless-stopped

--- a/waveform-generator/docker-compose.yml
+++ b/waveform-generator/docker-compose.yml
@@ -14,6 +14,6 @@ services:
       - ../../config/waveform-generator-config-envs
     logging:
       driver: "json-file"
-    restart: "no"
+    restart: on-failure
     depends_on:
       - waveform-reader

--- a/waveform-reader/docker-compose.yml
+++ b/waveform-reader/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       - "7777:7777"
     logging:
       driver: "json-file"
-    restart: "no"
+    restart: on-failure
     volumes:
       - ../../waveform-test-data:/waveform-test-data:ro
     depends_on:


### PR DESCRIPTION
Tweak container restart policies to increase their chances of coming back if the host restarts or the container crashes.

When our docker host last rebooted, only cassandra, core and glowroot came back for emap-dev. In particular, the waveform-reader didn't come back, and unknown to me there was some data directing to it that we wanted to keep.

So trying to prevent this happening again.

I can't explain why core came back but rabbitmq didn't, since they both had "on-failure" before this change. And more containers depend on rabbitmq than core, so I don't think that's the cause.

I'm aware that some containers need to be able to exit cleanly without being restarted (hl7-reader and hoover), so nothing more aggressive than "on-failure" can be used in that case. This could be a problem because the docs say:

> The on-failure policy only prompts a restart if the container exits with a failure. It doesn't restart the container if the daemon restarts.

We certainly want hl7-reader to come back following a docker daemon (or host) restart, so this may require further work.