### PR TITLE
Waveform generator sends a synthetic opt-out message with every admission

### DIFF
--- a/waveform-generator/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform_generator/Hl7Generator.java
+++ b/waveform-generator/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform_generator/Hl7Generator.java
@@ -13,8 +13,6 @@ import org.springframework.stereotype.Component;
 import uk.ac.ucl.rits.inform.datasources.waveform.LocationMapping;
 import uk.ac.ucl.rits.inform.datasources.waveform_generator.patient_model.PatientLocationModel;
 import uk.ac.ucl.rits.inform.interchange.EmapOperationMessage;
-import uk.ac.ucl.rits.inform.interchange.adt.AdmitPatient;
-import uk.ac.ucl.rits.inform.interchange.adt.AdtMessage;
 import uk.ac.ucl.rits.inform.interchange.messaging.Publisher;
 
 import javax.annotation.PostConstruct;
@@ -128,7 +126,7 @@ public class Hl7Generator {
     public void generateMessages() throws IOException {
         if (!haveInitialised) {
             haveInitialised = true;
-            List<AdmitPatient> initialAdmits = patientLocationModel.getInitialLocations();
+            List<EmapOperationMessage> initialAdmits = patientLocationModel.getInitialLocations();
             logger.info("First scheduled run, perform initial admits: {} messages", initialAdmits.size());
             submitBatch(initialAdmits);
         }
@@ -358,7 +356,7 @@ public class Hl7Generator {
                 new SyntheticStream("52912", 0, 50, 0.3, 5), // airway volume
                 new SyntheticStream("27", 3, 300, 1.2, 10) // ECG
         );
-        List<AdtMessage> locationChangeMessages = patientLocationModel.makeModifications(startTime);
+        List<EmapOperationMessage> locationChangeMessages = patientLocationModel.makeModifications(startTime);
         submitBatch(locationChangeMessages);
 
         List<String> empties = new ArrayList<>();
@@ -398,7 +396,7 @@ public class Hl7Generator {
         return waveformMsgs;
     }
 
-    private void submitBatch(List<? extends AdtMessage> adtMsgs) {
+    private void submitBatch(List<? extends EmapOperationMessage> adtMsgs) {
         List<ImmutablePair<EmapOperationMessage, String>> batch = new ArrayList<>();
         int i = 0;
         for (var adt: adtMsgs) {

--- a/waveform-generator/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform_generator/patient_model/PatientDetails.java
+++ b/waveform-generator/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform_generator/patient_model/PatientDetails.java
@@ -5,7 +5,9 @@ import lombok.Setter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.ucl.rits.inform.datasources.waveform.LocationMapping;
+import uk.ac.ucl.rits.inform.interchange.EmapOperationMessage;
 import uk.ac.ucl.rits.inform.interchange.InterchangeValue;
+import uk.ac.ucl.rits.inform.interchange.ResearchOptOut;
 import uk.ac.ucl.rits.inform.interchange.adt.AdmitPatient;
 import uk.ac.ucl.rits.inform.interchange.adt.AdtMessage;
 import uk.ac.ucl.rits.inform.interchange.adt.DischargePatient;
@@ -13,6 +15,8 @@ import uk.ac.ucl.rits.inform.interchange.adt.TransferPatient;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Random;
 
 public class PatientDetails {
@@ -37,6 +41,8 @@ public class PatientDetails {
     // need to track admit time as non-admit HL7 ADT messages require it
     @Getter
     private final Instant admitDatetime;
+    @Getter
+    private final boolean isResearchOptOut;
 
     // datetime for latest event (transfer, discharge, etc)
     @Getter @Setter
@@ -86,6 +92,14 @@ public class PatientDetails {
         this.mrn = makeFakeMrn();
         this.csn = makeFakeCsn();
         this.nhsNumber = makeFakeNhsNumber();
+        // Make the same MRN always have the same opt out status
+        this.isResearchOptOut = chooseIsResearchOptOut(this.mrn);
+    }
+
+    private boolean chooseIsResearchOptOut(String stringToHash) {
+        // String.hashCode depends only on the contents of the string and is stable over time, so you can
+        // use an identifier such as the MRN to produce an arbitrary but repeatable opt out value.
+        return stringToHash.hashCode() % 10 == 0;
     }
 
     private String makeFakeNhsNumber() {
@@ -160,12 +174,23 @@ public class PatientDetails {
      * Interpret this set of patient details as if an admit had just happened.
      * @return an admit interchange message representing the admission
      */
-    public AdmitPatient makeAdmitMessage() {
+    public List<EmapOperationMessage> makeAdmitAndOptoutMessages() {
+        List<EmapOperationMessage> allMessages = new ArrayList<>();
         AdmitPatient admitPatient = new AdmitPatient();
         setGenericAdtFields(admitPatient);
         admitPatient.setFullLocationString(new InterchangeValue<>(getAdtLocation()));
         admitPatient.setAdmissionDateTime(new InterchangeValue<>(getAdmitDatetime()));
+        allMessages.add(admitPatient);
+        // always add an opt out message for new patients
+        allMessages.add(makeResearchOptOutMessage());
+        return allMessages;
+    }
 
-        return admitPatient;
+    private ResearchOptOut makeResearchOptOutMessage() {
+        ResearchOptOut researchOptOut = new ResearchOptOut(this.nhsNumber, this.mrn, this.admitDatetime, this.isResearchOptOut);
+        researchOptOut.setSourceMessageId(String.format(
+                "ROO_%s_%s", admitDatetime.toEpochMilli(), Instant.now().toEpochMilli()));
+        researchOptOut.setSourceSystem("synthetic_waveform_generator_ROO");
+        return researchOptOut;
     }
 }

--- a/waveform-generator/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform_generator/patient_model/PatientLocationModel.java
+++ b/waveform-generator/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform_generator/patient_model/PatientLocationModel.java
@@ -3,8 +3,7 @@ package uk.ac.ucl.rits.inform.datasources.waveform_generator.patient_model;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import uk.ac.ucl.rits.inform.datasources.waveform.LocationMapping;
-import uk.ac.ucl.rits.inform.interchange.adt.AdmitPatient;
-import uk.ac.ucl.rits.inform.interchange.adt.AdtMessage;
+import uk.ac.ucl.rits.inform.interchange.EmapOperationMessage;
 
 import java.time.Instant;
 import java.util.ArrayList;
@@ -42,15 +41,15 @@ public class PatientLocationModel {
      * Make initial set of admit messages, as if all the patients in locationToPatient have just been admitted.
      * @return one admit message per existing patient
      */
-    public List<AdmitPatient> getInitialLocations() {
-        List<AdmitPatient> admitMsgs = new ArrayList<>();
+    public List<EmapOperationMessage> getInitialLocations() {
+        List<EmapOperationMessage> admitMsgs = new ArrayList<>();
         locationToPatient.entrySet().stream().forEach(entry -> {
             PatientDetails initialPatient = entry.getValue();
             String location = entry.getKey();
             initialPatient.setEventDatetime(initialPatient.getAdmitDatetime());
             logger.info("Initial stats: {}, {}, {}", location, initialPatient.getAdmitDatetime(), initialPatient.getEventDatetime());
             initialPatient.setLocation(location);
-            admitMsgs.add(initialPatient.makeAdmitMessage());
+            admitMsgs.addAll(initialPatient.makeAdmitAndOptoutMessages());
         });
         return admitMsgs;
     }
@@ -61,7 +60,7 @@ public class PatientLocationModel {
      * @param nowTime time at which ADT changes will be simulated to happen
      * @return description of changes made
      */
-    public List<AdtMessage> makeModifications(Instant nowTime) {
+    public List<EmapOperationMessage> makeModifications(Instant nowTime) {
         List<PatientDetails> admitList = new ArrayList<>();
         List<PatientDetails> dischargeList = new ArrayList<>();
         List<PatientDetails> transferList = new ArrayList<>();
@@ -145,8 +144,8 @@ public class PatientLocationModel {
                 }
             }
         }
-        List<AdtMessage> mods = new ArrayList<>();
-        admitList.forEach(adm -> mods.add(adm.makeAdmitMessage()));
+        List<EmapOperationMessage> mods = new ArrayList<>();
+        admitList.forEach(adm -> mods.addAll(adm.makeAdmitAndOptoutMessages()));
         transferList.forEach(tr -> mods.add(tr.makeTransferMessage()));
         dischargeList.forEach(disch -> mods.add(disch.makeDischargeMessage()));
         return mods;


### PR DESCRIPTION
To test #155 , we need to set up the Emap DB so that some patients have opted out of research.


See https://github.com/SAFEHR-data/waveform-controller/pull/63 for main implementation of the opt-out.