### PR TITLE
Adjust synthetic generator params for faster performance and more realism

### DIFF
--- a/waveform-generator/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform_generator/Hl7Generator.java
+++ b/waveform-generator/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform_generator/Hl7Generator.java
@@ -353,8 +353,8 @@ public class Hl7Generator {
         List<String> waveformMsgs = new ArrayList<>();
         numPatients = Math.min(numPatients, possibleLocations.size());
         List<SyntheticStream> syntheticStreams = List.of(
-                new SyntheticStream("52912", 0, 50, 0.3, 5), // airway volume
-                new SyntheticStream("27", 3, 300, 1.2, 10) // ECG
+                new SyntheticStream("52912", 0, 50, 0.3, 50), // airway volume
+                new SyntheticStream("27", 3, 300, 1.2, 300) // ECG
         );
         List<EmapOperationMessage> locationChangeMessages = patientLocationModel.makeModifications(startTime);
         submitBatch(locationChangeMessages);

--- a/waveform-generator/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform_generator/patient_model/PatientLocationModel.java
+++ b/waveform-generator/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform_generator/patient_model/PatientLocationModel.java
@@ -66,10 +66,10 @@ public class PatientLocationModel {
         List<PatientDetails> transferList = new ArrayList<>();
 
         // probability of each patient being discharged/transferred at each time step
-        final float probOfDischarge = 0.01F;
-        final float probOfTransferOut = 0.01F;
-        final float probOfTransferWithin = 0.01F;
-        final float probOfTransferIn = 0.01F;
+        final float probOfDischarge = 0.0005F;
+        final float probOfTransferOut = 0.0005F;
+        final float probOfTransferWithin = 0.0005F;
+        final float probOfTransferIn = 0.0005F;
 
         // go through all locations and randomly move some patients out
         for (int i = 0; i < allPossibleLocations.size(); i++) {


### PR DESCRIPTION
Real HL7 waveform messages contain about 1 second of data. Although splitting them up into tiny messages was a good stress test for the waveform reader, this is now unnecessarily slow.

Also don't move patients around so frequently. This produced a large number of small parquet files in the final output, which increased FTP notifications for no real benefit.