### PR TITLE
Speed up emap-star waveform table writes by ~50%

### DIFF
--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/WaveformArray.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/WaveformArray.java
@@ -12,7 +12,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Types;
 import java.util.Arrays;
-import java.util.Objects;
 
 public class WaveformArray implements UserType {
     @Override
@@ -27,12 +26,21 @@ public class WaveformArray implements UserType {
 
     @Override
     public boolean equals(Object o, Object o1) throws HibernateException {
-        return Objects.equals(o, o1);
+        if (o == o1) {
+            return true;
+        }
+        if (o == null || o1 == null) {
+            return false;
+        }
+        // ensure that we check on the *values* and not just the references as Double[] .equals() would do
+        Double[] a = (Double[]) o;
+        Double[] b = (Double[]) o1;
+        return Arrays.equals(a, b);
     }
 
     @Override
     public int hashCode(Object o) throws HibernateException {
-        return Objects.hashCode(o);
+        return Arrays.hashCode((Double[]) o);
     }
 
     @Override


### PR DESCRIPTION
Hibernate needs to be able to tell if the in-memory object has changed vs what it thinks is in the database. It uses the `equals` method of the Entity object to do so. If it looks like it has changed, it will issue an UPDATE to the database.

Our `equals` method always returned false, thus causing an unecessary UPDATE shortly after we do the initial INSERT.

Objects.equals(a1, a2) delegates to a1.equals(a2) in the case of Java arrays, which only tests for referential equality! The fix is to use Arrays.equals(a1, a2), which tests for equality of the values inside.

(Note that this is not part of the Waveform export pipeline that we've been actively working on the last few months. This is the waveform table inside the Postgres DB.)