### PR TITLE
Speed up Emap by increasing DB sequence increment

### DIFF
--- a/core/src/main/java/uk/ac/ucl/rits/inform/datasinks/emapstar/repos/IdsEffectLogging.java
+++ b/core/src/main/java/uk/ac/ucl/rits/inform/datasinks/emapstar/repos/IdsEffectLogging.java
@@ -23,7 +23,7 @@ import java.time.Instant;
         indexes = {@Index(columnList = "sourceId", unique = false)})
 public class IdsEffectLogging {
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long id;
     private String sourceId;
     private Instant messageDatetime;

--- a/docs/SOP/release_procedure.md
+++ b/docs/SOP/release_procedure.md
@@ -16,6 +16,10 @@ At this point we create a list in the planner with vital things to be completed 
    1. Delete all data in the instance to be repopulated using script 
       `\\sharefs6\UCLH6\EMAP\Shared\EmapSqlScripts\devops\drop.sql`
 
+   1. Create the sequence that hibernate uses for @Id fields, as it doesn't
+      get created automatically in some circumstances.
+      `CREATE SEQUENCE IF NOT EXISTS "your_schema".emap_id_sequence INCREMENT 50;`
+
    1. Taking note of which branches of each repository are being used.
 
    1. Start off a run into the empty db.

--- a/docs/technical_overview/ADR/hibernate-sequence.md
+++ b/docs/technical_overview/ADR/hibernate-sequence.md
@@ -1,0 +1,43 @@
+# Hibernate Id field generation strategy
+
+Done as part of performance improvement work in March 2026.
+
+## Decisions
+
+* Switched from AUTO to SEQUENCE generation strategy for the primary key field
+all Hibernate entity classes.
+
+* This requires a database sequence to be created at DB init time,
+which was achieved with *documentation* telling the user to do it manually.
+
+## Reasoning
+
+AUTO strategy on Postgres leads to using a database
+sequence called `hibernate_sequence` with an increment of `1`. This means
+that hibernate has to do a round-trip to the database for every single database row
+it wishes to create so it can allocate a unique id value.
+This results in `select nextval(...)` being the most called SQL query by Hibernate,
+which accounts for a few % of overall running time.
+
+SEQUENCE strategy defaults to an INCREMENT (allocation size) value of 50, which means the sequence
+has to be called much less often. For each call, Hibernate knows it can use all values
+between the current value and current value + 49 before it has to ask again for a value.
+I also gave it a new name (`emap_id_sequence`) to avoid it accidentally using any stale
+`hibernate_sequence` objects that might still exist (and be configured to an increment of 1).
+
+This caused a problem, in that there seems to be a bug/feature of Hibernate in that it only
+automatically creates sequences if that sequence doesn't already exist in *any* schema in the database.
+Since we differentiate different instances of Emap by schemas on the same database, this means that
+it will only get created on the first instance you run.
+
+I tried a few things like adding `SequenceGenerator` and/or `SequenceStyleGenerator` to TemporalCore,
+but it didn't help.
+
+In the end I decided that manually creating the sequence isn't that big a deal and have added this
+step to the deployment documentation.
+
+# Future work
+
+We should probably initialise our database using a database migration tool such as Liquibase.
+Getting Hibernate to do the exact thing in SQL that you want it to do can has been a problem before
+(notably when trying to make the SQL Server version).

--- a/emap-star/README.md
+++ b/emap-star/README.md
@@ -44,7 +44,7 @@ relational database. We have chosen a relational structure for ease of use and e
     * This is the primary key for the department table.
     */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long departmentId;  
     ```
 
@@ -62,7 +62,7 @@ relational database. We have chosen a relational structure for ease of use and e
     ```
   - In Java, these are defined as `Long` types, which default to null, before auto generation. `long` would default to 0.
     ```java
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long mrnId;
     ```
 - Foreign keys use the same name as the primary key

--- a/emap-star/emap-star-annotations/src/main/java/uk/ac/ucl/rits/inform/informdb/annotation/AuditTableProcessor.java
+++ b/emap-star/emap-star-annotations/src/main/java/uk/ac/ucl/rits/inform/informdb/annotation/AuditTableProcessor.java
@@ -270,7 +270,10 @@ public class AuditTableProcessor extends AbstractProcessor {
         List<FieldStore> fieldShorts = new ArrayList<>();
 
         // Primary key
-        this.generateSingleField(out, "\t@Id\n\t@GeneratedValue(strategy = GenerationType.AUTO)", "Long", primaryKey);
+        this.generateSingleField(
+                out,
+                "\t@Id\n\t@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = \"emap_id_sequence\")",
+                "Long", primaryKey);
 
         // All other fields
         for (VariableElement field : fields) {

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/AllergenReaction.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/AllergenReaction.java
@@ -35,7 +35,7 @@ public class AllergenReaction extends TemporalCore<AllergenReaction, AllergenRea
      * This is the primary key for the allergenReaction table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long allergenReactionId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/ConditionType.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/ConditionType.java
@@ -33,7 +33,7 @@ public class ConditionType extends TemporalCore<ConditionType, ConditionTypeAudi
      * This is the primary key for the conditionType table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long conditionTypeId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/ConditionVisits.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/ConditionVisits.java
@@ -37,7 +37,7 @@ public class ConditionVisits {
      * This is the primary key for the ConditionVisits table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long conditionVisitsId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/PatientCondition.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/conditions/PatientCondition.java
@@ -43,7 +43,7 @@ public class PatientCondition extends TemporalCore<PatientCondition, PatientCond
      * This is the primary key for the patientCondition table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long patientConditionId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/consults/ConsultationRequest.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/consults/ConsultationRequest.java
@@ -32,7 +32,7 @@ public class ConsultationRequest extends TemporalCore<ConsultationRequest, Consu
      * This is the primary key for the consultationRequest table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long consultationRequestId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/consults/ConsultationType.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/consults/ConsultationType.java
@@ -33,7 +33,7 @@ public class ConsultationType extends TemporalCore<ConsultationType, Consultatio
      * This is the primary key for the consultationType table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long consultationTypeId;
     @Column(nullable = false, unique = true)
 

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/decisions/AdvanceDecision.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/decisions/AdvanceDecision.java
@@ -33,7 +33,7 @@ public class AdvanceDecision extends TemporalCore<AdvanceDecision, AdvanceDecisi
      * This is the primary key for the advanceDecision table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long advanceDecisionId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/decisions/AdvanceDecisionType.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/decisions/AdvanceDecisionType.java
@@ -26,7 +26,7 @@ public class AdvanceDecisionType {
      * This is the primary key for the advanceDecisionType table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long advanceDecisionTypeId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/demographics/CoreDemographic.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/demographics/CoreDemographic.java
@@ -44,7 +44,7 @@ public class CoreDemographic extends TemporalCore<CoreDemographic, CoreDemograph
      * This is the primary key for the coreDemographics table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long coreDemographicId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/forms/Form.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/forms/Form.java
@@ -38,7 +38,7 @@ public class Form extends TemporalCore<Form, FormAudit> {
      * \brief Unique identifier in EMAP for this instance of a Form.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long formId;
 
     /* There is no concept of an instance ID here

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/forms/FormAnswer.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/forms/FormAnswer.java
@@ -31,7 +31,7 @@ public class FormAnswer extends TemporalCore<FormAnswer, FormAnswerAudit> {
      * \brief Unique identifier in EMAP for this instance of a Form.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long formAnswerId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/forms/FormDefinition.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/forms/FormDefinition.java
@@ -28,7 +28,7 @@ public class FormDefinition extends TemporalCore<FormDefinition, FormDefinitionA
      * \brief Unique identifier in EMAP for this Form description record.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long formDefinitionId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/forms/FormQuestion.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/forms/FormQuestion.java
@@ -28,7 +28,7 @@ public class FormQuestion extends TemporalCore<FormQuestion, FormQuestionAudit> 
      * \brief Unique identifier in EMAP.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long formQuestionId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/identity/HospitalVisit.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/identity/HospitalVisit.java
@@ -50,7 +50,7 @@ public class HospitalVisit extends TemporalCore<HospitalVisit, HospitalVisitAudi
      * This is the primary key for the HospitalVisit table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long hospitalVisitId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/identity/Mrn.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/identity/Mrn.java
@@ -46,7 +46,7 @@ public class Mrn implements Serializable {
      * This is the primary key for the mrn table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long mrnId;
 
     //TODO Exclude from doxygen

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/identity/MrnToLive.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/identity/MrnToLive.java
@@ -41,7 +41,7 @@ public class MrnToLive extends TemporalCore<MrnToLive, MrnToLiveAudit> {
      * This is the primary key for the MrnToLive table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long mrnToLiveId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabBattery.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabBattery.java
@@ -31,7 +31,7 @@ public class LabBattery extends TemporalCore<LabBattery, LabBatteryAudit> {
      * This is the primary key for the labBattery table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long labBatteryId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabBatteryElement.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabBatteryElement.java
@@ -35,7 +35,7 @@ public class LabBatteryElement extends TemporalCore<LabBatteryElement, LabBatter
      * This is the primary key for the labBatteryElement table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long labBatteryElementId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabIsolate.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabIsolate.java
@@ -32,7 +32,7 @@ public class LabIsolate extends TemporalCore<LabIsolate, LabIsolateAudit> {
      * This is the primary key for the labIsolate table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long labIsolateId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabOrder.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabOrder.java
@@ -43,7 +43,7 @@ public class LabOrder extends TemporalCore<LabOrder, LabOrderAudit> {
      * This is the primary key for the labOrder table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long labOrderId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabResult.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabResult.java
@@ -40,7 +40,7 @@ public class LabResult extends TemporalCore<LabResult, LabResultAudit> {
      * This is the primary key for the labResult table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long labResultId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabSample.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabSample.java
@@ -37,7 +37,7 @@ public class LabSample extends TemporalCore<LabSample, LabSampleAudit> {
      * This is the primary key for the labSample table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long labSampleId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabSensitivity.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabSensitivity.java
@@ -34,7 +34,7 @@ public class LabSensitivity extends TemporalCore<LabSensitivity, LabSensitivityA
      * This is the primary key for the labSensitivity table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long labSensitivityId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabTestDefinition.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/labs/LabTestDefinition.java
@@ -36,7 +36,7 @@ public class LabTestDefinition extends TemporalCore<LabTestDefinition, LabTestDe
      * This is the primary key for the labTestDefinition table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long labTestDefinitionId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/Bed.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/Bed.java
@@ -29,7 +29,7 @@ public class Bed implements Serializable {
      * This is the primary key for the bed table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long bedId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/BedFacility.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/BedFacility.java
@@ -29,7 +29,7 @@ public class BedFacility implements Serializable {
      * This is the primary key for the bedFacility table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long bedFacilityId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/BedState.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/BedState.java
@@ -33,7 +33,7 @@ public class BedState extends AuditCore<BedState> {
      * This is the primary key for the bedState table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long bedStateId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/Department.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/Department.java
@@ -27,7 +27,7 @@ public class Department implements Serializable {
      * This is the primary key for the department table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long departmentId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/DepartmentState.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/DepartmentState.java
@@ -33,7 +33,7 @@ public class DepartmentState extends AuditCore<DepartmentState> {
      * This is the primary key for the departmentState table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long departmentStateId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/Location.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/Location.java
@@ -29,7 +29,7 @@ public class Location implements  Serializable {
      * This is the primary key for the location table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long locationId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/LocationVisit.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/LocationVisit.java
@@ -54,7 +54,7 @@ public class LocationVisit extends TemporalCore<LocationVisit, LocationVisitAudi
      * This is the primary key for the locationVisit table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long locationVisitId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/PlannedMovement.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/PlannedMovement.java
@@ -43,7 +43,7 @@ public class PlannedMovement extends TemporalCore<PlannedMovement, PlannedMoveme
      * This is the primary key for the PlannedMovement table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long plannedMovementId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/Room.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/Room.java
@@ -29,7 +29,7 @@ public class Room implements Serializable {
      * This is the primary key for the room table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long roomId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/RoomState.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/movement/RoomState.java
@@ -33,7 +33,7 @@ public class RoomState extends AuditCore<RoomState> {
      * This is the primary key for the roomState table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private Long roomStateId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/questions/Question.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/questions/Question.java
@@ -32,7 +32,7 @@ public class Question {
      * This is the primary key for the question table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long questionId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/questions/RequestAnswer.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/questions/RequestAnswer.java
@@ -40,7 +40,7 @@ public class RequestAnswer extends TemporalCore<RequestAnswer, RequestAnswerAudi
      * This is the primary key for the requestAnswer table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long requestAnswerId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/VisitObservation.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/VisitObservation.java
@@ -47,7 +47,7 @@ public class VisitObservation extends TemporalCore<VisitObservation, VisitObserv
      * This is the primary key for the visitObservation table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long visitObservationId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/VisitObservationType.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/VisitObservationType.java
@@ -47,7 +47,7 @@ public class VisitObservationType extends TemporalCore<VisitObservationType, Vis
      * This is the primary key for the visitObservationType table.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.AUTO)
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long visitObservationTypeId;
 
     /**

--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/Waveform.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/Waveform.java
@@ -49,7 +49,7 @@ public class Waveform extends TemporalCore<Waveform, WaveformAudit> {
      * This is the primary key.
      */
     @Id
-    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "waveform_id_sequence")
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "emap_id_sequence")
     private long waveformId;
 
     /**


### PR DESCRIPTION
The single biggest SQL query in Emap was `select nextval('your_schema.hibernate_sequence')`, which had to be called once for every single row inserted into the database.

Details should be explained by `docs/technical_overview/ADR/hibernate-sequence.md`