### PR TITLE
Speed up Emap by adding a 3-column index 

### DIFF
--- a/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/VisitObservation.java
+++ b/emap-star/emap-star/src/main/java/uk/ac/ucl/rits/inform/informdb/visit_recordings/VisitObservation.java
@@ -33,7 +33,8 @@ import java.time.LocalDate;
 @Entity
 @Table(indexes = {@Index(name = "vo_hospital_visit_id", columnList = "hospitalVisitId"),
         @Index(name = "vo_visit_observation_type", columnList = "visitObservationTypeId"),
-        @Index(name = "vo_observation_datetime", columnList = "observationDatetime")})
+        @Index(name = "vo_observation_datetime", columnList = "observationDatetime"),
+        @Index(name = "vo_hospital_visit_type_datetime", columnList = "hospitalVisitId,visitObservationTypeId,observationDatetime")})
 @Data
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)


### PR DESCRIPTION
The query generated by `uk.ac.ucl.rits.inform.datasinks.emapstar.repos.visit_observations.VisitObservationRepository#findByHospitalVisitIdAndVisitObservationTypeIdAndObservationDatetime` is in the top ~5 of all queries by running time according to my 1-day sample.

We already had single-column indexes for each of the three columns in the query, but a single index of all three makes the query run about 30% faster. I didn't check which, if any, of the single column indexes were being used.

(Can old indexes be removed?)