### PR TITLE
Rename "stream" -> "variable"

### DIFF
--- a/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/Hl7ParseAndQueue.java
+++ b/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/Hl7ParseAndQueue.java
@@ -144,14 +144,14 @@ public class Hl7ParseAndQueue {
                 String variableId = obx.getField(3);
 
 
-                Optional<SourceMetadataItem> metadataOpt = sourceMetadata.getStreamMetadata(variableId);
+                Optional<SourceMetadataItem> metadataOpt = sourceMetadata.getVariableMetadata(variableId);
                 if (metadataOpt.isEmpty()) {
-                    logger.warn("Skipping stream {}, unrecognised streamID", variableId);
+                    logger.warn("Skipping variable {}, unrecognised variableID", variableId);
                     continue;
                 }
                 SourceMetadataItem metadata = metadataOpt.get();
                 if (!metadata.isUsable()) {
-                    logger.warn("Skipping stream {}, insufficient metadata", variableId);
+                    logger.warn("Skipping variable {}, insufficient metadata", variableId);
                     continue;
                 }
 
@@ -159,17 +159,17 @@ public class Hl7ParseAndQueue {
                 // shouldn't treat it as the channel!
                 String channelId = metadata.hasChannels() ? obr.getField(13) : null;
 
-                // Sampling rate and stream description is not in the message, so use the metadata
+                // Sampling rate and variable description is not in the message, so use the metadata
                 int samplingRate = metadata.samplingRate();
                 String mappedLocation = locationMapping.hl7AdtLocationFromCapsuleLocation(locationId);
-                String mappedStreamDescription = metadata.mappedStreamDescription();
+                String mappedVariableDescription = metadata.mappedVariableDescription();
                 String unit = metadata.unit();
 
                 // non-numerical types won't be able to go in the waveform table, but it's possible
                 // we might need them as a VisitObservation
                 String hl7Type = obx.getField(2);
                 if (!Set.of("NM", "NA").contains(hl7Type)) {
-                    logger.warn("Skipping stream {} with type {}, not numerical", variableId, hl7Type);
+                    logger.warn("Skipping variable {} with type {}, not numerical", variableId, hl7Type);
                     continue;
                 }
                 String allPointsStr = obx.getField(5);
@@ -184,7 +184,7 @@ public class Hl7ParseAndQueue {
                         locationId, obsDatetime, messageIdSpecific, points.size());
                 WaveformMessage waveformMessage = waveformMessageFromValues(
                         samplingRate, locationId, mappedLocation, obsDatetime, messageIdSpecific,
-                        variableId, mappedStreamDescription, channelId, unit, points);
+                        variableId, mappedVariableDescription, channelId, unit, points);
 
                 allWaveformMessages.add(waveformMessage);
             }

--- a/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/SourceMetadata.java
+++ b/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/SourceMetadata.java
@@ -21,14 +21,14 @@ import java.util.Optional;
 
 /**
  * The source data (from HL7 messages) is not fully self-describing.
- * We need external metadata to tell us certain things about each data stream.
+ * We need external metadata to tell us certain things about each data variable.
  */
 @Component
 public class SourceMetadata {
     private final Logger logger = LoggerFactory.getLogger(Hl7ParseAndQueue.class);
     private static final Resource VARIABLE_CSV = new ClassPathResource("source-metadata/Device_Values_formatted.csv");
     private static final Resource CHANNELS_CSV = new ClassPathResource("source-metadata/Carescape parameters.csv");
-    private Map<String, SourceMetadataItem> metadataByStreamId = new HashMap<>();
+    private Map<String, SourceMetadataItem> metadataByVariableId = new HashMap<>();
 
     SourceMetadata() throws IOException {
         logger.info("Loading metadata from {}", CHANNELS_CSV);
@@ -66,10 +66,10 @@ public class SourceMetadata {
             if (!metadataItem.isUsable()) {
                 logger.warn("Metadata item cannot be used for mapping: {}", VARIABLE_CSV);
             }
-            metadataByStreamId.put(key, metadataItem);
+            metadataByVariableId.put(key, metadataItem);
         }
         variablesMappingIterator.close();
-        logger.info("Loaded {} metadata items from {}", metadataByStreamId.size(), VARIABLE_CSV);
+        logger.info("Loaded {} metadata items from {}", metadataByVariableId.size(), VARIABLE_CSV);
     }
 
     private static MappingIterator<Map<String, String>> readCsv(Resource csvToRead) throws IOException {
@@ -85,29 +85,29 @@ public class SourceMetadata {
 
 
     /**
-     * Get metadata for the stream ID, if we know it (hence Optional).
-     * @param streamId stream unique ID
+     * Get metadata for the variable ID, if we know it (hence Optional).
+     * @param variableId variable unique ID
      * @return metadata record wrapped in Optional
      */
-    public Optional<SourceMetadataItem> getStreamMetadata(String streamId) {
-        SourceMetadataItem metadata = metadataByStreamId.get(streamId);
+    public Optional<SourceMetadataItem> getVariableMetadata(String variableId) {
+        SourceMetadataItem metadata = metadataByVariableId.get(variableId);
         if (metadata == null) {
             return Optional.empty();
         }
-        return Optional.of(new SourceMetadataItem(streamId, metadata.mappedStreamDescription(),
+        return Optional.of(new SourceMetadataItem(variableId, metadata.mappedVariableDescription(),
                 metadata.unit(), metadata.samplingRate(), metadata.channelIds()));
     }
 }
 
 /**
- * Describes a source stream.
- * @param sourceStreamId the source stream unique Id, Eg. "52912"
- * @param mappedStreamDescription Description of the stream eg. "Airway Volume Waveform"
+ * Describes a source variable.
+ * @param sourceVariableId the source variable unique Id, Eg. "52912"
+ * @param mappedVariableDescription Description of the variable eg. "Airway Volume Waveform"
  * @param unit The unit relating to the value, eg. "mL"
  * @param samplingRate number of samples per second, eg. 50
  * @param channelIds the names of the expected channels for this variable. Can be null or empty...
  */
-record SourceMetadataItem(String sourceStreamId, String mappedStreamDescription, String unit, Integer samplingRate, List<String> channelIds) {
+record SourceMetadataItem(String sourceVariableId, String mappedVariableDescription, String unit, Integer samplingRate, List<String> channelIds) {
     // allow unusable to exist for the sake of better logging messages
     public boolean isUsable() {
         // We need to know the sampling rate so we can check the data is free of gaps, for one thing

--- a/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/WaveformCollator.java
+++ b/waveform-reader/src/main/java/uk/ac/ucl/rits/inform/datasources/waveform/WaveformCollator.java
@@ -34,7 +34,7 @@ public class WaveformCollator {
 
     /**
      * Add short messages from the same patient for collating.
-     * @param messagesToAdd messages to add, can be for different location+stream
+     * @param messagesToAdd messages to add, can be for different location+variable+channel
      * @throws CollationException if a message duplicates another message
      */
     public void addMessages(List<WaveformMessage> messagesToAdd) throws CollationException {
@@ -54,9 +54,9 @@ public class WaveformCollator {
         }
 
         /* The bulk of time is spent only with a lock held on the data structure specific to
-         * the location+stream, thus enabling more parallelism.
+         * the location+variable+channel, thus enabling more parallelism.
          * Need lock because we may be trying to collate at the same time as we're adding here.
-         * Group together all the messages for a particular location+stream, so that the lock
+         * Group together all the messages for a particular location+variable+channel, so that the lock
          * for each one only needs to be taken out once.
          */
         for (var key: messagesToAddByKey.keySet()) {
@@ -90,7 +90,7 @@ public class WaveformCollator {
      *                        not make such an assumption.
      * @return the collated messages that are now ready for sending, may be empty if none are ready
      * @throws CollationException if any set within pendingMessages contains messages not in
-     *                             fact all from the same patient+stream
+     *                             fact all from the same location+variable+channel
      */
     public List<WaveformMessage> getReadyMessages(Instant nowTime,
                                                   int targetCollatedMessageSamples,
@@ -132,7 +132,7 @@ public class WaveformCollator {
 
 
     /**
-     * Given a sorted map of messages (all for same patient+stream), squash as much as possible
+     * Given a sorted map of messages (all for same location+variable+channel), squash as much as possible
      * into a single message, respecting the target number of samples. If a time gap is detected
      * in the sequence of messages, stop. Ie. do not straddle the gap within the same message.
      * Remove messages from the structure which were used as source data for the collated message.
@@ -143,7 +143,7 @@ public class WaveformCollator {
      * @param waitForDataLimitMillis see {@link #getReadyMessages}
      * @param assumedRounding see {@link #getReadyMessages}
      * @return the collated message, or null if the messages cannot be collated
-     * @throws CollationException if perPatientMap messages are not in fact all from the same patient+stream
+     * @throws CollationException if perPatientMap messages are not in fact all from the same location+variable+channel
      */
 
     private WaveformMessage collateContiguousData(SortedMap<Instant, WaveformMessage> perPatientMap,

--- a/waveform-reader/src/test/java/uk/ac/ucl/rits/inform/datasources/waveform/TestWaveformCollation.java
+++ b/waveform-reader/src/test/java/uk/ac/ucl/rits/inform/datasources/waveform/TestWaveformCollation.java
@@ -41,7 +41,7 @@ public class TestWaveformCollation {
     }
 
     List<WaveformMessage> makeTestMessages() {
-        // Check that we can handle adding messages from different streams,
+        // Check that we can handle adding messages from different variables+channels,
         // as would be found in a real HL7 message
         List<WaveformMessage> uncollatedMsgs = messageFactory.getWaveformMsgs(
                 "59912", "something1", null,
@@ -126,7 +126,7 @@ public class TestWaveformCollation {
         Instant now = messageStartDatetime.plus(nowAfterFirstMessageMillis, assumedRounding);
         List<WaveformMessage> allCollatedMsgs = waveformCollator.getReadyMessages(
                 now, targetNumSamples, waitForDataLimitMillis, assumedRounding);
-        // only test messages from one stream
+        // only test messages from one channel
         List<WaveformMessage> collatedMsgs =
                 allCollatedMsgs.stream().filter(msg -> waveformCollator.makeKey(msg).equals(keyOfInterest)).toList();
 
@@ -172,7 +172,7 @@ public class TestWaveformCollation {
         List<WaveformMessage> allCollatedMsgs = waveformCollator.getReadyMessages(
                 now, targetCollatedMessageSamples, waitForDataLimitMillis, ChronoUnit.MILLIS);
         Triple<String, String, String> keyOfInterest = new ImmutableTriple<>("UCHT03TEST", "59912", null);
-        // only test messages from one stream
+        // only test messages from one channel
         List<WaveformMessage> collatedMsgs =
                 allCollatedMsgs.stream().filter(msg -> waveformCollator.makeKey(msg).equals(keyOfInterest)).toList();
 


### PR DESCRIPTION
In preparation for upcoming changes for waveform settings/metadata, change terminology to reflect correct usage. This will make the later PR more focused.